### PR TITLE
Add mitsubishi_uart component from previous repo

### DIFF
--- a/esphome/components/mitsubishi_uart/__init__.py
+++ b/esphome/components/mitsubishi_uart/__init__.py
@@ -1,0 +1,327 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import (
+    climate,
+    uart,
+    sensor,
+    binary_sensor,
+    text_sensor,
+    select,
+    switch,
+)
+from esphome.const import (
+    CONF_ID,
+    CONF_NAME,
+    CONF_SUPPORTED_MODES,
+    CONF_CUSTOM_FAN_MODES,
+    CONF_SUPPORTED_FAN_MODES,
+    DEVICE_CLASS_TEMPERATURE,
+    DEVICE_CLASS_FREQUENCY,
+    ENTITY_CATEGORY_CONFIG,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_CELSIUS,
+    UNIT_HERTZ,
+)
+from esphome.core import coroutine
+
+AUTO_LOAD = ["climate", "select", "sensor", "binary_sensor", "text_sensor", "switch"]
+DEPENDENCIES = [
+    "uart",
+    "climate",
+    "sensor",
+    "binary_sensor",
+    "text_sensor",
+    "select",
+    "switch",
+]
+
+CONF_HP_UART = "heatpump_uart"
+CONF_TS_UART = "thermostat_uart"
+
+CONF_SENSORS = "sensors"
+CONF_SENSORS_THERMOSTAT_TEMP = "thermostat_temperature"
+CONF_SENSORS_ERROR_CODE = "error_code"
+
+CONF_SELECTS = "selects"
+CONF_TEMPERATURE_SOURCE_SELECT = "temperature_source_select"  # This is to create a Select object for selecting a source
+CONF_VANE_POSITION_SELECT = "vane_position_select"
+CONF_HORIZONTAL_VANE_POSITION_SELECT = "horizontal_vane_position_select"
+
+CONF_TEMPERATURE_SOURCES = (
+    "temperature_sources"  # This is for specifying additional sources
+)
+
+CONF_ACTIVE_MODE_SWITCH = "active_mode_switch"
+
+DEFAULT_POLLING_INTERVAL = "5s"
+
+mitsubishi_uart_ns = cg.esphome_ns.namespace("mitsubishi_uart")
+MitsubishiUART = mitsubishi_uart_ns.class_(
+    "MitsubishiUART", cg.PollingComponent, climate.Climate
+)
+
+TemperatureSourceSelect = mitsubishi_uart_ns.class_(
+    "TemperatureSourceSelect", select.Select
+)
+VanePositionSelect = mitsubishi_uart_ns.class_("VanePositionSelect", select.Select)
+HorizontalVanePositionSelect = mitsubishi_uart_ns.class_(
+    "HorizontalVanePositionSelect", select.Select
+)
+
+ActiveModeSwitch = mitsubishi_uart_ns.class_(
+    "ActiveModeSwitch", switch.Switch, cg.Component
+)
+
+DEFAULT_CLIMATE_MODES = ["OFF", "HEAT", "DRY", "COOL", "FAN_ONLY", "HEAT_COOL"]
+DEFAULT_FAN_MODES = ["AUTO", "QUIET", "LOW", "MEDIUM", "HIGH"]
+CUSTOM_FAN_MODES = {"VERYHIGH": mitsubishi_uart_ns.FAN_MODE_VERYHIGH}
+VANE_POSITIONS = ["Auto", "1", "2", "3", "4", "5", "Swing"]
+HORIZONTAL_VANE_POSITIONS = ["Auto", "<<", "<", "|", ">", ">>", "<>", "Swing"]
+
+INTERNAL_TEMPERATURE_SOURCE_OPTIONS = [
+    mitsubishi_uart_ns.TEMPERATURE_SOURCE_INTERNAL
+]  # These will always be available
+
+validate_custom_fan_modes = cv.enum(CUSTOM_FAN_MODES, upper=True)
+
+BASE_SCHEMA = (
+    cv.polling_component_schema(DEFAULT_POLLING_INTERVAL)
+    .extend(climate.CLIMATE_SCHEMA)
+    .extend(
+        {
+            cv.GenerateID(CONF_ID): cv.declare_id(MitsubishiUART),
+            cv.Required(CONF_HP_UART): cv.use_id(uart.UARTComponent),
+            cv.Optional(CONF_TS_UART): cv.use_id(uart.UARTComponent),
+            cv.Optional(CONF_NAME, default="Climate"): cv.string,
+            cv.Optional(
+                CONF_SUPPORTED_MODES, default=DEFAULT_CLIMATE_MODES
+            ): cv.ensure_list(climate.validate_climate_mode),
+            cv.Optional(
+                CONF_SUPPORTED_FAN_MODES, default=DEFAULT_FAN_MODES
+            ): cv.ensure_list(climate.validate_climate_fan_mode),
+            cv.Optional(CONF_CUSTOM_FAN_MODES, default=["VERYHIGH"]): cv.ensure_list(
+                validate_custom_fan_modes
+            ),
+            cv.Optional(CONF_TEMPERATURE_SOURCES, default=[]): cv.ensure_list(
+                cv.use_id(sensor.Sensor)
+            ),
+            cv.Optional(
+                CONF_ACTIVE_MODE_SWITCH, default={"name": "Active Mode"}
+            ): switch.switch_schema(
+                ActiveModeSwitch,
+                entity_category=ENTITY_CATEGORY_CONFIG,
+                default_restore_mode="RESTORE_DEFAULT_ON",
+                icon="mdi:upload-network",
+            ),
+        }
+    )
+)
+
+# TODO Storing the registration function here seems weird, but I can't figure out how to determine schema type later
+SENSORS = {
+    CONF_SENSORS_THERMOSTAT_TEMP: (
+        "Thermostat Temperature",
+        sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+            accuracy_decimals=1,
+        ),
+        sensor.register_sensor,
+    ),
+    "compressor_frequency": (
+        "Compressor Frequency",
+        sensor.sensor_schema(
+            unit_of_measurement=UNIT_HERTZ,
+            device_class=DEVICE_CLASS_FREQUENCY,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        sensor.register_sensor,
+    ),
+    "actual_fan": (
+        "Actual Fan Speed",
+        text_sensor.text_sensor_schema(
+            icon="mdi:fan",
+        ),
+        text_sensor.register_text_sensor,
+    ),
+    "service_filter": (
+        "Service Filter",
+        binary_sensor.binary_sensor_schema(),
+        binary_sensor.register_binary_sensor,
+    ),
+    "defrost": (
+        "Defrost",
+        binary_sensor.binary_sensor_schema(),
+        binary_sensor.register_binary_sensor,
+    ),
+    "hot_adjust": (
+        "Hot Adjust",
+        binary_sensor.binary_sensor_schema(),
+        binary_sensor.register_binary_sensor,
+    ),
+    "standby": (
+        "Standby",
+        binary_sensor.binary_sensor_schema(),
+        binary_sensor.register_binary_sensor,
+    ),
+    CONF_SENSORS_ERROR_CODE: (
+        "Error Code",
+        text_sensor.text_sensor_schema(),
+        text_sensor.register_text_sensor,
+    ),
+}
+
+SENSORS_SCHEMA = cv.All(
+    {
+        cv.Optional(
+            sensor_designator,
+            default={"name": f"{sensor_name}", "disabled_by_default": "true"},
+        ): sensor_schema
+        for sensor_designator, (
+            sensor_name,
+            sensor_schema,
+            registration_function,
+        ) in SENSORS.items()
+    }
+)
+
+SELECTS = {
+    CONF_TEMPERATURE_SOURCE_SELECT: (
+        "Temperature Source",
+        select.select_schema(
+            TemperatureSourceSelect,
+            entity_category=ENTITY_CATEGORY_CONFIG,
+            icon="mdi:thermometer-check",
+        ),
+        INTERNAL_TEMPERATURE_SOURCE_OPTIONS,
+    ),
+    CONF_VANE_POSITION_SELECT: (
+        "Vane Position",
+        select.select_schema(
+            VanePositionSelect,
+            entity_category=ENTITY_CATEGORY_CONFIG,
+            icon="mdi:arrow-expand-vertical",
+        ),
+        VANE_POSITIONS,
+    ),
+    CONF_HORIZONTAL_VANE_POSITION_SELECT: (
+        "Horizontal Vane Position",
+        select.select_schema(
+            HorizontalVanePositionSelect,
+            entity_category=ENTITY_CATEGORY_CONFIG,
+            icon="mdi:arrow-expand-horizontal",
+        ),
+        HORIZONTAL_VANE_POSITIONS,
+    ),
+}
+
+SELECTS_SCHEMA = cv.All(
+    {
+        cv.Optional(
+            select_designator, default={"name": f"{select_name}"}
+        ): select_schema
+        for select_designator, (
+            select_name,
+            select_schema,
+            select_options,
+        ) in SELECTS.items()
+    }
+)
+
+
+CONFIG_SCHEMA = BASE_SCHEMA.extend(
+    {
+        cv.Optional(CONF_SENSORS, default={}): SENSORS_SCHEMA,
+        cv.Optional(CONF_SELECTS, default={}): SELECTS_SCHEMA,
+    }
+)
+
+
+@coroutine
+async def to_code(config):
+    hp_uart_component = await cg.get_variable(config[CONF_HP_UART])
+    muart_component = cg.new_Pvariable(config[CONF_ID], hp_uart_component)
+
+    await cg.register_component(muart_component, config)
+    await climate.register_climate(muart_component, config)
+
+    # If thermostat defined
+    if CONF_TS_UART in config:
+        # Register thermostat with MUART
+        ts_uart_component = await cg.get_variable(config[CONF_TS_UART])
+        cg.add(getattr(muart_component, "set_thermostat_uart")(ts_uart_component))
+        # Add sensor as source
+        SELECTS[CONF_TEMPERATURE_SOURCE_SELECT][2].append("Thermostat")
+
+    # Traits
+
+    traits = muart_component.config_traits()
+
+    if CONF_SUPPORTED_MODES in config:
+        cg.add(traits.set_supported_modes(config[CONF_SUPPORTED_MODES]))
+
+    if CONF_SUPPORTED_FAN_MODES in config:
+        cg.add(traits.set_supported_fan_modes(config[CONF_SUPPORTED_FAN_MODES]))
+
+    if CONF_CUSTOM_FAN_MODES in config:
+        cg.add(traits.set_supported_custom_fan_modes(config[CONF_CUSTOM_FAN_MODES]))
+
+    # Sensors
+
+    for sensor_designator, (
+        sensor_name,
+        sensor_schema,
+        registration_function,
+    ) in SENSORS.items():
+        # Only add the thermostat temp if we have a TS_UART
+        if (sensor_designator == CONF_SENSORS_THERMOSTAT_TEMP) and (
+            CONF_TS_UART not in config
+        ):
+            continue
+
+        sensor_conf = config[CONF_SENSORS][sensor_designator]
+        sensor_component = cg.new_Pvariable(sensor_conf[CONF_ID])
+
+        await registration_function(sensor_component, sensor_conf)
+
+        cg.add(
+            getattr(muart_component, f"set_{sensor_designator}_sensor")(
+                sensor_component
+            )
+        )
+
+    # Selects
+
+    # Add additional configured temperature sensors to the select menu
+    for ts_id in config[CONF_TEMPERATURE_SOURCES]:
+        ts = await cg.get_variable(ts_id)
+        SELECTS[CONF_TEMPERATURE_SOURCE_SELECT][2].append(ts.get_name())
+        cg.add(
+            getattr(ts, "add_on_state_callback")(
+                # TODO: Is there anyway to do this without a raw expression?
+                cg.RawExpression(
+                    f"[](float v){{{getattr(muart_component, 'temperature_source_report')}({ts.get_name()}, v);}}"
+                )
+            )
+        )
+
+    # Register selects
+    for select_designator, (
+        select_name,
+        select_schema,
+        select_options,
+    ) in SELECTS.items():
+        select_conf = config[CONF_SELECTS][select_designator]
+        select_component = cg.new_Pvariable(select_conf[CONF_ID])
+        await select.register_select(
+            select_component, select_conf, options=select_options
+        )
+        cg.add(getattr(muart_component, f"set_{select_designator}")(select_component))
+        await cg.register_parented(select_component, muart_component)
+
+    # Switches
+    if am_switch_conf := config.get(CONF_ACTIVE_MODE_SWITCH):
+        switch_component = await switch.new_switch(am_switch_conf)
+        await cg.register_component(switch_component, am_switch_conf)
+        await cg.register_parented(switch_component, muart_component)

--- a/esphome/components/mitsubishi_uart/mitsubishi_uart-climatecall.cpp
+++ b/esphome/components/mitsubishi_uart/mitsubishi_uart-climatecall.cpp
@@ -1,0 +1,98 @@
+#include "mitsubishi_uart.h"
+
+namespace esphome {
+namespace mitsubishi_uart {
+
+// Called to instruct a change of the climate controls
+void MitsubishiUART::control(const climate::ClimateCall &call) {
+  if (!active_mode)
+    return;  // If we're not in active mode, ignore control requests
+
+  SettingsSetRequestPacket setRequestPacket = SettingsSetRequestPacket();
+
+  // Fan
+
+  if (call.get_custom_fan_mode().has_value()) {
+    if (call.get_custom_fan_mode().value() == FAN_MODE_VERYHIGH) {
+      set_custom_fan_mode_(FAN_MODE_VERYHIGH);
+      setRequestPacket.setFan(SettingsSetRequestPacket::FAN_4);
+    }
+  }
+
+  switch (call.get_fan_mode().value()) {
+    case climate::CLIMATE_FAN_QUIET:
+      set_fan_mode_(climate::CLIMATE_FAN_QUIET);
+      setRequestPacket.setFan(SettingsSetRequestPacket::FAN_QUIET);
+      break;
+    case climate::CLIMATE_FAN_LOW:
+      set_fan_mode_(climate::CLIMATE_FAN_LOW);
+      setRequestPacket.setFan(SettingsSetRequestPacket::FAN_1);
+      break;
+    case climate::CLIMATE_FAN_MEDIUM:
+      set_fan_mode_(climate::CLIMATE_FAN_MEDIUM);
+      setRequestPacket.setFan(SettingsSetRequestPacket::FAN_2);
+      break;
+    case climate::CLIMATE_FAN_HIGH:
+      set_fan_mode_(climate::CLIMATE_FAN_HIGH);
+      setRequestPacket.setFan(SettingsSetRequestPacket::FAN_3);
+      break;
+    case climate::CLIMATE_FAN_AUTO:
+      set_fan_mode_(climate::CLIMATE_FAN_AUTO);
+      setRequestPacket.setFan(SettingsSetRequestPacket::FAN_AUTO);
+      break;
+    default:
+      ESP_LOGW(TAG, "Unhandled fan mode %i!", call.get_fan_mode().value());
+      break;
+  }
+
+  // Mode
+
+  if (call.get_mode().has_value()) {
+    mode = call.get_mode().value();
+
+    switch (call.get_mode().value()) {
+      case climate::CLIMATE_MODE_HEAT_COOL:
+        setRequestPacket.setPower(true).setMode(SettingsSetRequestPacket::MODE_BYTE_AUTO);
+        break;
+      case climate::CLIMATE_MODE_COOL:
+        setRequestPacket.setPower(true).setMode(SettingsSetRequestPacket::MODE_BYTE_COOL);
+        break;
+      case climate::CLIMATE_MODE_HEAT:
+        setRequestPacket.setPower(true).setMode(SettingsSetRequestPacket::MODE_BYTE_HEAT);
+        break;
+      case climate::CLIMATE_MODE_FAN_ONLY:
+        setRequestPacket.setPower(true).setMode(SettingsSetRequestPacket::MODE_BYTE_FAN);
+        break;
+      case climate::CLIMATE_MODE_DRY:
+        setRequestPacket.setPower(true).setMode(SettingsSetRequestPacket::MODE_BYTE_DRY);
+        break;
+      case climate::CLIMATE_MODE_OFF:
+      default:
+        setRequestPacket.setPower(false);
+        break;
+    }
+  }
+
+  // Target Temperature
+
+  if (call.get_target_temperature().has_value()) {
+    target_temperature = call.get_target_temperature().value();
+    setRequestPacket.setTargetTemperature(call.get_target_temperature().value());
+  }
+
+  // TODO:
+  // Vane
+  // HVane?
+  // Swing?
+
+  // We're assuming that every climate call *does* make some change worth sending to the heat pump
+  // Queue the packet to be sent first (so any subsequent update packets come *after* our changes)
+  hp_bridge.sendPacket(setRequestPacket);
+
+  // Publish state and any sensor changes (shouldn't be any a a result of this function, but
+  // since they lazy-publish, no harm in trying)
+  doPublish();
+};
+
+}  // namespace mitsubishi_uart
+}  // namespace esphome

--- a/esphome/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
+++ b/esphome/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
@@ -1,0 +1,345 @@
+#include "mitsubishi_uart.h"
+
+namespace esphome {
+namespace mitsubishi_uart {
+
+void MitsubishiUART::routePacket(const Packet &packet) {
+  // If the packet is associated with the thermostat and just came from the thermostat, send it to the heatpump
+  // If it came from the heatpump, send it back to the thermostat
+  if (packet.getControllerAssociation() == ControllerAssociation::thermostat) {
+    if (packet.getSourceBridge() == SourceBridge::thermostat) {
+      hp_bridge.sendPacket(packet);
+    } else if (packet.getSourceBridge() == SourceBridge::heatpump) {
+      ts_bridge->sendPacket(packet);
+    }
+  }
+}
+
+// Packet Handlers
+void MitsubishiUART::processPacket(const Packet &packet) {
+  ESP_LOGI(TAG, "Generic unhandled packet type %x received.", packet.getPacketType());
+  ESP_LOGD(TAG, "%s", packet.to_string().c_str());
+  routePacket(packet);
+};
+
+void MitsubishiUART::processPacket(const ConnectRequestPacket &packet) {
+  // Nothing to be done for these except forward them along from thermostat to heat pump.
+  // This method defined so that these packets are not "unhandled"
+  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+  routePacket(packet);
+};
+void MitsubishiUART::processPacket(const ConnectResponsePacket &packet) {
+  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+  routePacket(packet);
+  // Not sure if there's any needed content in this response, so assume we're connected.
+  hpConnected = true;
+  ESP_LOGI(TAG, "Heatpump connected.");
+};
+
+void MitsubishiUART::processPacket(const ExtendedConnectRequestPacket &packet) {
+  // Nothing to be done for these except forward them along from thermostat to heat pump.
+  // This method defined so that these packets are not "unhandled"
+  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+  routePacket(packet);
+};
+void MitsubishiUART::processPacket(const ExtendedConnectResponsePacket &packet) {
+  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+  routePacket(packet);
+  // Not sure if there's any needed content in this response, so assume we're connected.
+  // TODO: Is there more useful info in these?
+  hpConnected = true;
+  _capabilitiesCache = packet;
+  ESP_LOGI(TAG, "Received heat pump identification packet.");
+};
+
+void MitsubishiUART::processPacket(const GetRequestPacket &packet) {
+  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+  routePacket(packet);
+  // These are just requests for information from the thermostat.  For now, nothing to be done
+  // except route them.  In the future, we could use this to inject information for the thermostat
+  // or use a cached value.
+}
+
+void MitsubishiUART::processPacket(const SettingsGetResponsePacket &packet) {
+  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+  routePacket(packet);
+
+  // Mode
+
+  const climate::ClimateMode old_mode = mode;
+  if (packet.getPower()) {
+    switch (packet.getMode()) {
+      case 0x01:
+        mode = climate::CLIMATE_MODE_HEAT;
+        break;
+      case 0x02:
+        mode = climate::CLIMATE_MODE_DRY;
+        break;
+      case 0x03:
+        mode = climate::CLIMATE_MODE_COOL;
+        break;
+      case 0x07:
+        mode = climate::CLIMATE_MODE_FAN_ONLY;
+        break;
+      case 0x08:
+        mode = climate::CLIMATE_MODE_HEAT_COOL;
+        break;
+      default:
+        mode = climate::CLIMATE_MODE_OFF;
+    }
+  } else {
+    mode = climate::CLIMATE_MODE_OFF;
+  }
+
+  publishOnUpdate |= (old_mode != mode);
+
+  // Temperature
+  const float old_target_temperature = target_temperature;
+  target_temperature = packet.getTargetTemp();
+  publishOnUpdate |= (old_target_temperature != target_temperature);
+
+  // Fan
+  static bool fanChanged = false;
+  switch (packet.getFan()) {
+    case 0x00:
+      fanChanged = set_fan_mode_(climate::CLIMATE_FAN_AUTO);
+      break;
+    case 0x01:
+      fanChanged = set_fan_mode_(climate::CLIMATE_FAN_QUIET);
+      break;
+    case 0x02:
+      fanChanged = set_fan_mode_(climate::CLIMATE_FAN_LOW);
+      break;
+    case 0x03:
+      fanChanged = set_fan_mode_(climate::CLIMATE_FAN_MEDIUM);
+      break;
+    case 0x05:
+      fanChanged = set_fan_mode_(climate::CLIMATE_FAN_HIGH);
+      break;
+    case 0x06:
+      fanChanged = set_custom_fan_mode_(FAN_MODE_VERYHIGH);
+      break;
+  }
+
+  publishOnUpdate |= fanChanged;
+
+  // TODO: It would probably be nice to have the enum->string mapping defined somewhere to avoid typos/errors
+  const std::string old_vane_position = vane_position_select->state;
+  switch (packet.getVane()) {
+    case SettingsSetRequestPacket::VANE_AUTO:
+      vane_position_select->state = "Auto";
+      break;
+    case SettingsSetRequestPacket::VANE_1:
+      vane_position_select->state = "1";
+      break;
+    case SettingsSetRequestPacket::VANE_2:
+      vane_position_select->state = "2";
+      break;
+    case SettingsSetRequestPacket::VANE_3:
+      vane_position_select->state = "3";
+      break;
+    case SettingsSetRequestPacket::VANE_4:
+      vane_position_select->state = "4";
+      break;
+    case SettingsSetRequestPacket::VANE_5:
+      vane_position_select->state = "5";
+      break;
+    case SettingsSetRequestPacket::VANE_SWING:
+      vane_position_select->state = "Swing";
+      break;
+    default:
+      ESP_LOGW(TAG, "Vane in unknown position %x", packet.getVane());
+  }
+  publishOnUpdate |= (old_vane_position != vane_position_select->state);
+
+  const std::string old_horizontal_vane_position = horizontal_vane_position_select->state;
+  switch (packet.getHorizontalVane()) {
+    case SettingsSetRequestPacket::HV_AUTO:
+      horizontal_vane_position_select->state = "Auto";
+      break;
+    case SettingsSetRequestPacket::HV_LEFT_FULL:
+      horizontal_vane_position_select->state = "<<";
+      break;
+    case SettingsSetRequestPacket::HV_LEFT:
+      horizontal_vane_position_select->state = "<";
+      break;
+    case SettingsSetRequestPacket::HV_CENTER:
+      horizontal_vane_position_select->state = "|";
+      break;
+    case SettingsSetRequestPacket::HV_RIGHT:
+      horizontal_vane_position_select->state = ">";
+      break;
+    case SettingsSetRequestPacket::HV_RIGHT_FULL:
+      horizontal_vane_position_select->state = ">>";
+      break;
+    case SettingsSetRequestPacket::HV_SPLIT:
+      horizontal_vane_position_select->state = "<>";
+      break;
+    case SettingsSetRequestPacket::HV_SWING:
+      horizontal_vane_position_select->state = "Swing";
+      break;
+    default:
+      ESP_LOGW(TAG, "Vane in unknown horizontal position %x", packet.getHorizontalVane());
+  }
+  publishOnUpdate |= (old_horizontal_vane_position != horizontal_vane_position_select->state);
+};
+
+void MitsubishiUART::processPacket(const CurrentTempGetResponsePacket &packet) {
+  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+  routePacket(packet);
+  // This will be the same as the remote temperature if we're using a remote sensor, otherwise the internal temp
+  const float old_current_temperature = current_temperature;
+  current_temperature = packet.getCurrentTemp();
+
+  publishOnUpdate |= (old_current_temperature != current_temperature);
+};
+
+void MitsubishiUART::processPacket(const StatusGetResponsePacket &packet) {
+  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+  routePacket(packet);
+  const climate::ClimateAction old_action = action;
+
+  // If mode is off, action is off
+  if (mode == climate::CLIMATE_MODE_OFF) {
+    action = climate::CLIMATE_ACTION_OFF;
+  }
+  // If mode is fan only, packet.getOperating() may be false, but the fan is running
+  else if (mode == climate::CLIMATE_MODE_FAN_ONLY) {
+    action = climate::CLIMATE_ACTION_FAN;
+  }
+  // If mode is anything other than off or fan, and the unit is operating, determine the action
+  else if (packet.getOperating()) {
+    switch (mode) {
+      case climate::CLIMATE_MODE_HEAT:
+        action = climate::CLIMATE_ACTION_HEATING;
+        break;
+      case climate::CLIMATE_MODE_COOL:
+        action = climate::CLIMATE_ACTION_COOLING;
+        break;
+      case climate::CLIMATE_MODE_DRY:
+        action = climate::CLIMATE_ACTION_DRYING;
+        break;
+      // TODO: This only works if we get an update while the temps are in this configuration
+      // Surely there's some info from the heat pump about which of these modes it's in?
+      case climate::CLIMATE_MODE_HEAT_COOL:
+        if (current_temperature > target_temperature) {
+          action = climate::CLIMATE_ACTION_COOLING;
+        } else if (current_temperature < target_temperature) {
+          action = climate::CLIMATE_ACTION_HEATING;
+        }
+        // When the heat pump *changes* to a new action, these temperature comparisons should be accurate.
+        // If the mode hasn't changed, but the temps are equal, we can assume the same action and make no change.
+        // If the unit overshoots, this still doesn't work.
+        break;
+      default:
+        ESP_LOGW(TAG, "Unhandled mode %i.", mode);
+        break;
+    }
+  }
+  // If we're not operating (but not off or in fan mode), we're idle
+  // Should be relatively safe to fall through any unknown modes into showing IDLE
+  else {
+    action = climate::CLIMATE_ACTION_IDLE;
+  }
+
+  publishOnUpdate |= (old_action != action);
+
+  if (compressor_frequency_sensor) {
+    const float old_compressor_frequency = compressor_frequency_sensor->raw_state;
+
+    compressor_frequency_sensor->raw_state = packet.getCompressorFrequency();
+
+    publishOnUpdate |= (old_compressor_frequency != compressor_frequency_sensor->raw_state);
+  }
+};
+void MitsubishiUART::processPacket(const StandbyGetResponsePacket &packet) {
+  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+  routePacket(packet);
+
+  if (service_filter_sensor) {
+    const bool old_service_filter = service_filter_sensor->state;
+    service_filter_sensor->state = packet.serviceFilter();
+    publishOnUpdate |= (old_service_filter != service_filter_sensor->state);
+  }
+
+  if (defrost_sensor) {
+    const bool old_defrost = defrost_sensor->state;
+    defrost_sensor->state = packet.inDefrost();
+    publishOnUpdate |= (old_defrost != defrost_sensor->state);
+  }
+
+  if (hot_adjust_sensor) {
+    const bool old_hot_adjust = hot_adjust_sensor->state;
+    hot_adjust_sensor->state = packet.inHotAdjust();
+    publishOnUpdate |= (old_hot_adjust != hot_adjust_sensor->state);
+  }
+
+  if (standby_sensor) {
+    const bool old_standby = standby_sensor->state;
+    standby_sensor->state = packet.inStandby();
+    publishOnUpdate |= (old_standby != standby_sensor->state);
+  }
+
+  if (actual_fan_sensor) {
+    const auto old_actual_fan = actual_fan_sensor->raw_state;
+    actual_fan_sensor->raw_state = ACTUAL_FAN_SPEED_NAMES[packet.getActualFanSpeed()];
+    publishOnUpdate |= (old_actual_fan != actual_fan_sensor->raw_state);
+  }
+
+  // TODO: Not sure what AutoMode does yet
+}
+
+void MitsubishiUART::processPacket(const ErrorStateGetResponsePacket &packet) {
+  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+  routePacket(packet);
+
+  std::string oldErrorCode = error_code_sensor->raw_state;
+
+  // TODO: Include friendly text from JSON, somehow.
+  if (!packet.errorPresent()) {
+    error_code_sensor->raw_state = "No Error Reported";
+  } else if (auto rawCode = packet.getRawShortCode() != 0x00) {
+    // Not that it matters, but good for validation I guess.
+    if ((rawCode & 0x1F) > 0x15) {
+      ESP_LOGW(TAG, "Error short code %x had invalid low bits. This is an IT protocol violation!", rawCode);
+    }
+
+    error_code_sensor->raw_state = "Error " + packet.getShortCode();
+  } else {
+    error_code_sensor->raw_state = "Error " + to_string(packet.getErrorCode());
+  }
+
+  publishOnUpdate |= (oldErrorCode != error_code_sensor->raw_state);
+}
+
+void MitsubishiUART::processPacket(const RemoteTemperatureSetRequestPacket &packet) {
+  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+
+  // Only send this temperature packet to the heatpump if Thermostat is the selected source,
+  // or we're in passive mode (since in passive mode we're not generating any packets to
+  // set the temperature) otherwise just respond to the thermostat to keep it happy.
+  if (currentTemperatureSource == TEMPERATURE_SOURCE_THERMOSTAT || !active_mode) {
+    routePacket(packet);
+  } else {
+    ts_bridge->sendPacket(SetResponsePacket());
+  }
+
+  float t = packet.getRemoteTemperature();
+  temperature_source_report(TEMPERATURE_SOURCE_THERMOSTAT, t);
+
+  if (thermostat_temperature_sensor) {
+    const float old_thermostat_temp = thermostat_temperature_sensor->raw_state;
+
+    thermostat_temperature_sensor->raw_state = t;
+
+    publishOnUpdate |= (old_thermostat_temp != thermostat_temperature_sensor->raw_state);
+  }
+};
+void MitsubishiUART::processPacket(const SetResponsePacket &packet) {
+  ESP_LOGV(TAG, "Got Set Response packet, success = %s (code = %x)", packet.isSuccessful() ? "true" : "false",
+           packet.getResultCode());
+  routePacket(packet);
+}
+
+}  // namespace mitsubishi_uart
+}  // namespace esphome

--- a/esphome/components/mitsubishi_uart/mitsubishi_uart.cpp
+++ b/esphome/components/mitsubishi_uart/mitsubishi_uart.cpp
@@ -1,0 +1,306 @@
+#include "mitsubishi_uart.h"
+
+namespace esphome {
+namespace mitsubishi_uart {
+
+////
+// MitsubishiUART
+////
+
+MitsubishiUART::MitsubishiUART(uart::UARTComponent *hp_uart_comp)
+    : hp_uart{*hp_uart_comp}, hp_bridge{HeatpumpBridge(hp_uart_comp, this)} {
+  /**
+   * Climate pushes all its data to Home Assistant immediately when the API connects, this causes
+   * the default 0 to be sent as temperatures, but since this is a valid value (0 deg C), it
+   * can cause confusion and mess with graphs when looking at the state in HA.  Setting this to
+   * NAN gets HA to treat this value as "unavailable" until we have a real value to publish.
+   */
+  target_temperature = NAN;
+  current_temperature = NAN;
+}
+
+// Used to restore state of previous MUART-specific settings (like temperature source or pass-thru mode)
+// Most other climate-state is preserved by the heatpump itself and will be retrieved after connection
+void MitsubishiUART::setup() {
+  // Populate select map
+  for (size_t index = 0; index < temperature_source_select->traits.get_options().size(); index++) {
+    temp_select_map[temperature_source_select->traits.get_options()[index]] = index;
+  }
+
+  // Using App.get_compilation_time() means these will get reset each time the firmware is updated, but this
+  // is an easy way to prevent wierd conflicts if e.g. select options change.
+  preferences_ = global_preferences->make_preference<MUARTPreferences>(get_object_id_hash() ^
+                                                                       fnv1_hash(App.get_compilation_time()));
+  restore_preferences();
+}
+
+void MitsubishiUART::save_preferences() {
+  MUARTPreferences prefs{};
+
+  // currentTemperatureSource
+  // Save the index of the value stored in currentTemperatureSource just in case we're temporarily using Internal
+  auto index = temp_select_map.find(currentTemperatureSource);
+  if (index != temp_select_map.end()) {
+    prefs.currentTemperatureSourceIndex = index->second;
+  }
+
+  preferences_.save(&prefs);
+}
+
+// Restores previously set values, or sets sane defaults
+void MitsubishiUART::restore_preferences() {
+  MUARTPreferences prefs;
+  if (preferences_.load(&prefs)) {
+    // currentTemperatureSource
+    if (prefs.currentTemperatureSourceIndex.has_value() &&
+        temperature_source_select->has_index(prefs.currentTemperatureSourceIndex.value()) &&
+        temperature_source_select->at(prefs.currentTemperatureSourceIndex.value()).has_value()) {
+      currentTemperatureSource = temperature_source_select->at(prefs.currentTemperatureSourceIndex.value()).value();
+      temperature_source_select->publish_state(currentTemperatureSource);
+      ESP_LOGCONFIG(TAG, "Preferences loaded.");
+    } else {
+      ESP_LOGCONFIG(TAG, "Preferences loaded, but unsuitable values.");
+      currentTemperatureSource = TEMPERATURE_SOURCE_INTERNAL;
+      temperature_source_select->publish_state(TEMPERATURE_SOURCE_INTERNAL);
+    }
+  } else {
+    // TODO: Shouldn't need to define setting all these defaults twice
+    ESP_LOGCONFIG(TAG, "Preferences not loaded.");
+    currentTemperatureSource = TEMPERATURE_SOURCE_INTERNAL;
+    temperature_source_select->publish_state(TEMPERATURE_SOURCE_INTERNAL);
+  }
+}
+
+void MitsubishiUART::sendIfActive(const Packet &packet) {
+  if (active_mode)
+    hp_bridge.sendPacket(packet);
+}
+
+#define IFACTIVE(dothis) \
+  if (active_mode) { \
+    dothis \
+  }
+#define IFNOTACTIVE(dothis) \
+  if (!active_mode) { \
+    dothis \
+  }
+
+/* Used for receiving and acting on incoming packets as soon as they're available.
+  Because packet processing happens as part of the receiving process, packet processing
+  should not block for very long (e.g. no publishing inside the packet processing)
+*/
+void MitsubishiUART::loop() {
+  // Loop bridge to handle sending and receiving packets
+  hp_bridge.loop();
+  if (ts_bridge)
+    ts_bridge->loop();
+
+  // If it's been too long since we received a temperature update (and we're not set to Internal)
+  if (((millis() - lastReceivedTemperature) > TEMPERATURE_SOURCE_TIMEOUT_MS) &&
+      (temperature_source_select->state != TEMPERATURE_SOURCE_INTERNAL)) {
+    ESP_LOGW(TAG, "No temperature received from %s for %i milliseconds, reverting to Internal source",
+             currentTemperatureSource.c_str(), TEMPERATURE_SOURCE_TIMEOUT_MS);
+    // Set the select to show Internal (but do not change currentTemperatureSource)
+    temperature_source_select->publish_state(TEMPERATURE_SOURCE_INTERNAL);
+    // Send a packet to the heat pump to tell it to switch to internal temperature sensing
+    IFACTIVE(hp_bridge.sendPacket(RemoteTemperatureSetRequestPacket().useInternalTemperature());)
+  }
+  //
+  // Send packet to HP to tell it to use internal temp sensor
+}
+
+void MitsubishiUART::dump_config() {
+  if (_capabilitiesCache.has_value()) {
+    ESP_LOGCONFIG(TAG, "Discovered Capabilities: %s", _capabilitiesCache.value().to_string().c_str());
+  }
+}
+
+/* Called periodically as PollingComponent; used to send packets to connect or request updates.
+
+Possible TODO: If we only publish during updates, since data is received during loop, updates will always
+be about `update_interval` late from their actual time.  Generally the update interval should be low enough
+(default is 5seconds) this won't pose a practical problem.
+*/
+void MitsubishiUART::update() {
+  // TODO: Temporarily wait 5 seconds on startup to help with viewing logs
+  if (millis() < 5000) {
+    return;
+  }
+
+  // If we're not yet connected, send off a connection request (we'll check again next update)
+  if (!hpConnected) {
+    IFACTIVE(hp_bridge.sendPacket(ConnectRequestPacket::instance());)
+    return;
+  }
+
+  // Attempt to read capabilities on the next loop after connect.
+  // TODO: This should likely be done immediately after connect, and will likely need to block setup for proper
+  // autoconf.
+  //       For now, just requesting it as part of our "init loops" is a good first step.
+  if (!this->_capabilitiesRequested) {
+    IFACTIVE(hp_bridge.sendPacket(ExtendedConnectRequestPacket::instance()); this->_capabilitiesRequested = true;)
+  }
+
+  // Before requesting additional updates, publish any changes waiting from packets received
+  if (publishOnUpdate) {
+    doPublish();
+
+    publishOnUpdate = false;
+  }
+
+  IFACTIVE(
+      // Request an update from the heatpump
+      // TODO: This isn't a problem *yet*, but sending all these packets every loop might start to cause some issues in
+      //       certain configurations or setups. We may want to consider only asking for certain packets on a rarer
+      //       cadence, depending on their utility (e.g. we dont need to check for errors every loop).
+      hp_bridge.sendPacket(
+          GetRequestPacket::getSettingsInstance());  // Needs to be done before status packet for mode logic to work
+      hp_bridge.sendPacket(GetRequestPacket::getStandbyInstance());
+      hp_bridge.sendPacket(GetRequestPacket::getStatusInstance());
+      hp_bridge.sendPacket(GetRequestPacket::getCurrentTempInstance());
+      hp_bridge.sendPacket(GetRequestPacket::getErrorInfoInstance());)
+}
+
+void MitsubishiUART::doPublish() {
+  publish_state();
+  vane_position_select->publish_state(vane_position_select->state);
+  horizontal_vane_position_select->publish_state(horizontal_vane_position_select->state);
+  save_preferences();  // We can save this every time we publish as writes to flash are by default collected and delayed
+
+  // Check sensors and publish if needed.
+  // This is a bit of a hack to avoid needing to publish sensor data immediately as packets arrive.
+  // Instead, packet data is written directly to `raw_state` (which doesn't update `state`).  If they
+  // differ, calling `publish_state` will update `state` so that it won't be published later
+  if (thermostat_temperature_sensor &&
+      (thermostat_temperature_sensor->raw_state != thermostat_temperature_sensor->state)) {
+    ESP_LOGI(TAG, "Thermostat temp differs, do publish");
+    thermostat_temperature_sensor->publish_state(thermostat_temperature_sensor->raw_state);
+  }
+  if (compressor_frequency_sensor && (compressor_frequency_sensor->raw_state != compressor_frequency_sensor->state)) {
+    ESP_LOGI(TAG, "Compressor frequency differs, do publish");
+    compressor_frequency_sensor->publish_state(compressor_frequency_sensor->raw_state);
+  }
+  if (actual_fan_sensor && (actual_fan_sensor->raw_state != actual_fan_sensor->state)) {
+    ESP_LOGI(TAG, "Actual fan speed differs, do publish");
+    actual_fan_sensor->publish_state(actual_fan_sensor->raw_state);
+  }
+  if (error_code_sensor && (error_code_sensor->raw_state != error_code_sensor->state)) {
+    ESP_LOGI(TAG, "Error code state differs, do publish");
+    error_code_sensor->publish_state(error_code_sensor->raw_state);
+  }
+
+  // Binary sensors automatically dedup publishes (I think) and so will only actually publish on change
+  service_filter_sensor->publish_state(service_filter_sensor->state);
+  defrost_sensor->publish_state(defrost_sensor->state);
+  hot_adjust_sensor->publish_state(hot_adjust_sensor->state);
+  standby_sensor->publish_state(standby_sensor->state);
+}
+
+bool MitsubishiUART::select_temperature_source(const std::string &state) {
+  // TODO: Possibly check to see if state is available from the select options?  (Might be a bit redundant)
+
+  currentTemperatureSource = state;
+  // Reset the timeout for received temperature (without this, the menu dropdown will switch back to Internal
+  // temporarily)
+  lastReceivedTemperature = millis();
+
+  // If we've switched to internal, let the HP know right away
+  if (TEMPERATURE_SOURCE_INTERNAL == state) {
+    IFACTIVE(hp_bridge.sendPacket(RemoteTemperatureSetRequestPacket().useInternalTemperature());)
+  }
+
+  return true;
+}
+
+bool MitsubishiUART::select_vane_position(const std::string &state) {
+  IFNOTACTIVE(return false;)  // Skip this if we're not in active mode
+  SettingsSetRequestPacket::VANE_BYTE positionByte = SettingsSetRequestPacket::VANE_AUTO;
+
+  // NOTE: Annoyed that C++ doesn't have switches for strings, but since this is going to be called
+  // infrequently, this is probably a better solution than over-optimizing via maps or something
+
+  if (state == "Auto") {
+    positionByte = SettingsSetRequestPacket::VANE_AUTO;
+  } else if (state == "1") {
+    positionByte = SettingsSetRequestPacket::VANE_1;
+  } else if (state == "2") {
+    positionByte = SettingsSetRequestPacket::VANE_2;
+  } else if (state == "3") {
+    positionByte = SettingsSetRequestPacket::VANE_3;
+  } else if (state == "4") {
+    positionByte = SettingsSetRequestPacket::VANE_4;
+  } else if (state == "5") {
+    positionByte = SettingsSetRequestPacket::VANE_5;
+  } else if (state == "Swing") {
+    positionByte = SettingsSetRequestPacket::VANE_SWING;
+  } else {
+    ESP_LOGW(TAG, "Unknown vane position %s", state.c_str());
+    return false;
+  }
+
+  hp_bridge.sendPacket(SettingsSetRequestPacket().setVane(positionByte));
+  return true;
+}
+
+bool MitsubishiUART::select_horizontal_vane_position(const std::string &state) {
+  IFNOTACTIVE(return false;)  // Skip this if we're not in active mode
+  SettingsSetRequestPacket::HORIZONTAL_VANE_BYTE positionByte = SettingsSetRequestPacket::HV_CENTER;
+
+  // NOTE: Annoyed that C++ doesn't have switches for strings, but since this is going to be called
+  // infrequently, this is probably a better solution than over-optimizing via maps or something
+
+  if (state == "Auto") {
+    positionByte = SettingsSetRequestPacket::HV_AUTO;
+  } else if (state == "<<") {
+    positionByte = SettingsSetRequestPacket::HV_LEFT_FULL;
+  } else if (state == "<") {
+    positionByte = SettingsSetRequestPacket::HV_LEFT;
+  } else if (state == "|") {
+    positionByte = SettingsSetRequestPacket::HV_CENTER;
+  } else if (state == ">") {
+    positionByte = SettingsSetRequestPacket::HV_RIGHT;
+  } else if (state == ">>") {
+    positionByte = SettingsSetRequestPacket::HV_RIGHT_FULL;
+  } else if (state == "<>") {
+    positionByte = SettingsSetRequestPacket::HV_SPLIT;
+  } else if (state == "Swing") {
+    positionByte = SettingsSetRequestPacket::HV_SWING;
+  } else {
+    ESP_LOGW(TAG, "Unknown horizontal vane position %s", state.c_str());
+    return false;
+  }
+
+  hp_bridge.sendPacket(SettingsSetRequestPacket().setHorizontalVane(positionByte));
+  return true;
+}
+
+// Called by temperature_source sensors to report values.  Will only take action if the currentTemperatureSource
+// matches the incoming source.  Specifically this means that we are not storing any values
+// for sensors other than the current source, and selecting a different source won't have any
+// effect until that source reports a temperature.
+// TODO: ? Maybe store all temperatures (and report on them using internal sensors??) so that selecting a new
+// source takes effect immediately?  Only really needed if source sensors are configured with very slow update times.
+void MitsubishiUART::temperature_source_report(const std::string &temperature_source, const float &v) {
+  ESP_LOGI(TAG, "Received temperature from %s of %f. (Current source: %s)", temperature_source.c_str(), v,
+           currentTemperatureSource.c_str());
+
+  // Only proceed if the incomming source matches our chosen source.
+  if (currentTemperatureSource == temperature_source) {
+    // Reset the timeout for received temperature
+    lastReceivedTemperature = millis();
+
+    // Tell the heat pump about the temperature asap, but don't worry about setting it locally, the next update() will
+    // get it
+    IFACTIVE(RemoteTemperatureSetRequestPacket pkt = RemoteTemperatureSetRequestPacket(); pkt.setRemoteTemperature(v);
+             hp_bridge.sendPacket(pkt);)
+
+    // If we've changed the select to reflect a temporary reversion to a different source, change it back.
+    if (temperature_source_select->state != temperature_source) {
+      ESP_LOGI(TAG, "Temperature received, switching back to %s as source.", temperature_source.c_str());
+      temperature_source_select->publish_state(temperature_source);
+    }
+  }
+}
+
+}  // namespace mitsubishi_uart
+}  // namespace esphome

--- a/esphome/components/mitsubishi_uart/mitsubishi_uart.h
+++ b/esphome/components/mitsubishi_uart/mitsubishi_uart.h
@@ -1,0 +1,188 @@
+#pragma once
+
+#include "esphome/core/application.h"
+#include "esphome/core/component.h"
+#include "esphome/core/preferences.h"
+#include "esphome/components/uart/uart.h"
+#include "esphome/components/climate/climate.h"
+#include "esphome/components/select/select.h"
+#include "esphome/components/sensor/sensor.h"
+#include "muart_packet.h"
+#include "muart_bridge.h"
+#include <map>
+
+namespace esphome {
+namespace mitsubishi_uart {
+
+static const char *TAG = "mitsubishi_uart";
+
+const uint8_t MUART_MIN_TEMP = 16;  // Degrees C
+const uint8_t MUART_MAX_TEMP = 31;  // Degrees C
+const float MUART_TEMPERATURE_STEP = 0.5;
+
+const std::string FAN_MODE_VERYHIGH = "Very High";
+
+const std::string TEMPERATURE_SOURCE_INTERNAL = "Internal";
+const uint32_t TEMPERATURE_SOURCE_TIMEOUT_MS = 420000;  // (7min) The heatpump will revert on its own in ~10min
+
+const std::string TEMPERATURE_SOURCE_THERMOSTAT = "Thermostat";
+
+// these names come from Kumo. They are bad, but I am also too lazy to think of better names. they also
+// may not map perfectly yet?
+const std::array<std::string, 7> ACTUAL_FAN_SPEED_NAMES = {"Off",      "Very Low",       "Quiet",      "Low",
+                                                           "Powerful", "Super Powerful", "Super Quiet"};
+
+class MitsubishiUART : public PollingComponent, public climate::Climate, public PacketProcessor {
+ public:
+  /**
+   * Create a new MitsubishiUART with the specified esphome::uart::UARTComponent.
+   */
+  MitsubishiUART(uart::UARTComponent *hp_uart_comp);
+
+  // Used to restore state of previous MUART-specific settings (like temperature source or pass-thru mode)
+  // Most other climate-state is preserved by the heatpump itself and will be retrieved after connection
+  void setup() override;
+
+  // Called repeatedly (used for UART receiving/forwarding)
+  void loop() override;
+
+  // Called periodically as PollingComponent (used for UART sending periodically)
+  void update() override;
+
+  // Returns default traits for MUART
+  climate::ClimateTraits traits() override { return climate_traits_; }
+
+  // Returns a reference to traits for MUART to be used during configuration
+  // TODO: Maybe replace this with specific functions for the traits needed in configuration (a la the override
+  // fuctions)
+  climate::ClimateTraits &config_traits() { return climate_traits_; }
+
+  // Dumps some configuration data that we may have missed in the real-time logs
+  void dump_config();
+
+  // Called to instruct a change of the climate controls
+  void control(const climate::ClimateCall &call) override;
+
+  // Set thermostat UART component
+  void set_thermostat_uart(uart::UARTComponent *uart) {
+    ESP_LOGCONFIG(TAG, "Thermostat uart was set.");
+    ts_uart = uart;
+    ts_bridge = new ThermostatBridge(ts_uart, static_cast<PacketProcessor *>(this));
+  }
+
+  // Sensor setters
+  void set_thermostat_temperature_sensor(sensor::Sensor *sensor) { thermostat_temperature_sensor = sensor; };
+  void set_compressor_frequency_sensor(sensor::Sensor *sensor) { compressor_frequency_sensor = sensor; };
+  void set_actual_fan_sensor(text_sensor::TextSensor *sensor) { actual_fan_sensor = sensor; };
+  void set_service_filter_sensor(binary_sensor::BinarySensor *sensor) { service_filter_sensor = sensor; };
+  void set_defrost_sensor(binary_sensor::BinarySensor *sensor) { defrost_sensor = sensor; };
+  void set_hot_adjust_sensor(binary_sensor::BinarySensor *sensor) { hot_adjust_sensor = sensor; };
+  void set_standby_sensor(binary_sensor::BinarySensor *sensor) { standby_sensor = sensor; };
+  void set_error_code_sensor(text_sensor::TextSensor *sensor) { error_code_sensor = sensor; };
+
+  // Select setters
+  void set_temperature_source_select(select::Select *select) { temperature_source_select = select; };
+  void set_vane_position_select(select::Select *select) { vane_position_select = select; };
+  void set_horizontal_vane_position_select(select::Select *select) { horizontal_vane_position_select = select; };
+
+  // Returns true if select was valid (even if not yet successful) to indicate select component
+  // should optimistically publish
+  bool select_temperature_source(const std::string &state);
+  bool select_vane_position(const std::string &state);
+  bool select_horizontal_vane_position(const std::string &state);
+
+  // Used by external sources to report a temperature
+  void temperature_source_report(const std::string &temperature_source, const float &v);
+
+  // Turns on or off actively sending packets
+  void set_active_mode(const bool active) { active_mode = active; };
+
+ protected:
+  void routePacket(const Packet &packet);
+
+  void processPacket(const Packet &packet);
+  void processPacket(const ConnectRequestPacket &packet);
+  void processPacket(const ConnectResponsePacket &packet);
+  void processPacket(const ExtendedConnectRequestPacket &packet);
+  void processPacket(const ExtendedConnectResponsePacket &packet);
+  void processPacket(const GetRequestPacket &packet);
+  void processPacket(const SettingsGetResponsePacket &packet);
+  void processPacket(const CurrentTempGetResponsePacket &packet);
+  void processPacket(const StatusGetResponsePacket &packet);
+  void processPacket(const StandbyGetResponsePacket &packet);
+  void processPacket(const ErrorStateGetResponsePacket &packet);
+  void processPacket(const RemoteTemperatureSetRequestPacket &packet);
+  void processPacket(const SetResponsePacket &packet);
+
+  void doPublish();
+
+ private:
+  // Default climate_traits for MUART
+  climate::ClimateTraits climate_traits_ = []() -> climate::ClimateTraits {
+    climate::ClimateTraits ct = climate::ClimateTraits();
+
+    ct.set_supports_action(true);
+    ct.set_supports_current_temperature(true);
+    ct.set_supports_two_point_target_temperature(false);
+    ct.set_visual_min_temperature(MUART_MIN_TEMP);
+    ct.set_visual_max_temperature(MUART_MAX_TEMP);
+    ct.set_visual_temperature_step(MUART_TEMPERATURE_STEP);
+
+    return ct;
+  }();
+
+  // UARTComponent connected to heatpump
+  const uart::UARTComponent &hp_uart;
+  // UART packet wrapper for heatpump
+  HeatpumpBridge hp_bridge;
+  // UARTComponent connected to thermostat
+  uart::UARTComponent *ts_uart = nullptr;
+  // UART packet wrapper for heatpump
+  ThermostatBridge *ts_bridge = nullptr;
+
+  // Are we connected to the heatpump?
+  bool hpConnected = false;
+  // Should we call publish on the next update?
+  bool publishOnUpdate = false;
+
+  optional<ExtendedConnectResponsePacket> _capabilitiesCache;
+  bool _capabilitiesRequested = false;
+
+  // Preferences
+  void save_preferences();
+  void restore_preferences();
+
+  ESPPreferenceObject preferences_;
+
+  // Internal sensors
+  sensor::Sensor *thermostat_temperature_sensor = nullptr;
+  sensor::Sensor *compressor_frequency_sensor = nullptr;
+  text_sensor::TextSensor *actual_fan_sensor = nullptr;
+  binary_sensor::BinarySensor *service_filter_sensor = nullptr;
+  binary_sensor::BinarySensor *defrost_sensor = nullptr;
+  binary_sensor::BinarySensor *hot_adjust_sensor = nullptr;
+  binary_sensor::BinarySensor *standby_sensor = nullptr;
+  text_sensor::TextSensor *error_code_sensor = nullptr;
+
+  // Selects
+  select::Select *temperature_source_select;
+  select::Select *vane_position_select;
+  select::Select *horizontal_vane_position_select;
+
+  // Temperature select extras
+  std::map<std::string, size_t> temp_select_map;  // Used to map strings to indexes for preference storage
+  std::string currentTemperatureSource = TEMPERATURE_SOURCE_INTERNAL;
+  uint32_t lastReceivedTemperature = millis();
+
+  void sendIfActive(const Packet &packet);
+  bool active_mode = true;
+};
+
+struct MUARTPreferences {
+  optional<size_t> currentTemperatureSourceIndex = nullopt;  // Index of selected value
+  // optional<uint32_t> currentTemperatureSourceHash = nullopt; // Hash of selected value (to make sure it hasn't
+  // changed since last save)
+};
+
+}  // namespace mitsubishi_uart
+}  // namespace esphome

--- a/esphome/components/mitsubishi_uart/muart_bridge.cpp
+++ b/esphome/components/mitsubishi_uart/muart_bridge.cpp
@@ -1,0 +1,207 @@
+#include "muart_bridge.h"
+
+namespace esphome {
+namespace mitsubishi_uart {
+
+MUARTBridge::MUARTBridge(uart::UARTComponent *uart_component, PacketProcessor *packet_processor)
+    : uart_comp{*uart_component}, pkt_processor{*packet_processor} {}
+
+// The heatpump loop expects responses for most sent packets, so it tracks the last send packet and wait for a response
+void HeatpumpBridge::loop() {
+  // Try to get a packet
+  if (optional<RawPacket> pkt =
+          receiveRawPacket(SourceBridge::heatpump, packetAwaitingResponse.has_value()
+                                                       ? packetAwaitingResponse.value().getControllerAssociation()
+                                                       : ControllerAssociation::muart)) {
+    ESP_LOGV(BRIDGE_TAG, "Parsing %x heatpump packet", pkt.value().getPacketType());
+    // Check the packet's checksum and either process it, or log an error
+    if (pkt.value().isChecksumValid()) {
+      // If we're waiting for a response, associate the incomming packet with the request packet
+      classifyAndProcessRawPacket(pkt.value());
+    } else {
+      ESP_LOGW(BRIDGE_TAG, "Invalid packet checksum!\n%s",
+               format_hex_pretty(&pkt.value().getBytes()[0], pkt.value().getLength()).c_str());
+    }
+
+    // If there was a packet waiting for a response, remove it.
+    // TODO: This incoming packet wasn't *nessesarily* a response, but for now
+    // it's probably not worth checking to make sure it matches.
+    if (packetAwaitingResponse.has_value()) {
+      packetAwaitingResponse.reset();
+    }
+  } else if (!packetAwaitingResponse.has_value() && !pkt_queue.empty()) {
+    // If we're not waiting for a response and there's a packet in the queue...
+
+    // If the packet expects a response, add it to the awaitingResponse variable
+    if (pkt_queue.front().isResponseExpected()) {
+      packetAwaitingResponse = pkt_queue.front();
+    }
+
+    ESP_LOGV(BRIDGE_TAG, "Sending to heatpump %s", pkt_queue.front().to_string().c_str());
+    writeRawPacket(pkt_queue.front().rawPacket());
+    packet_sent_millis = millis();
+
+    // Remove packet from queue
+    pkt_queue.pop();
+  } else if (packetAwaitingResponse.has_value() && (millis() - packet_sent_millis > RESPONSE_TIMEOUT_MS)) {
+    // We've been waiting too long for a response, give up
+    // TODO: We could potentially retry here, but that seems unnecessary
+    packetAwaitingResponse.reset();
+    ESP_LOGW(BRIDGE_TAG, "Timeout waiting for response to %x packet.", packetAwaitingResponse.value().getPacketType());
+  }
+}
+
+// The thermostat bridge loop doesn't expect any responses, so packets in queue are just sent without checking if they
+// expect a response
+void ThermostatBridge::loop() {
+  // Try to get a packet
+  if (optional<RawPacket> pkt = receiveRawPacket(SourceBridge::thermostat, ControllerAssociation::thermostat)) {
+    ESP_LOGV(BRIDGE_TAG, "Parsing %x thermostat packet", pkt.value().getPacketType());
+    // Check the packet's checksum and either process it, or log an error
+    if (pkt.value().isChecksumValid()) {
+      classifyAndProcessRawPacket(pkt.value());
+    } else {
+      ESP_LOGW(BRIDGE_TAG, "Invalid packet checksum!\n%s",
+               format_hex_pretty(&pkt.value().getBytes()[0], pkt.value().getLength()).c_str());
+    }
+  } else if (!pkt_queue.empty()) {
+    // If there's a packet in the queue...
+
+    ESP_LOGV(BRIDGE_TAG, "Sending to thermostat %s", pkt_queue.front().to_string().c_str());
+    writeRawPacket(pkt_queue.front().rawPacket());
+    packet_sent_millis = millis();
+
+    // Remove packet from queue
+    pkt_queue.pop();
+  }
+}
+
+/* Queues a packet to be sent by the bridge.  If the queue is full, the packet will not be
+enqueued.*/
+void MUARTBridge::sendPacket(const Packet &packetToSend) {
+  if (pkt_queue.size() <= MAX_QUEUE_SIZE) {
+    pkt_queue.push(packetToSend);
+  } else {
+    ESP_LOGW(BRIDGE_TAG, "Packet queue full!  %x packet not sent.", packetToSend.getPacketType());
+  }
+}
+
+void MUARTBridge::writeRawPacket(const RawPacket &packetToSend) const {
+  uart_comp.write_array(packetToSend.getBytes(), packetToSend.getLength());
+}
+
+/* Reads and deserializes a packet from UART.
+Communication with heatpump is *slow*, so we need to check and make sure there are
+enough packets available before we start reading.  If there aren't enough packets,
+no packet will be returned.
+
+Even at 2400 baud, the 100ms readtimeout should be enough to read a whole payload
+after the first byte has been received though, so currently we're assuming that once
+the header is available, it's safe to call read_array without timing out and severing
+the packet.
+*/
+const optional<RawPacket> MUARTBridge::receiveRawPacket(const SourceBridge source_bridge,
+                                                        const ControllerAssociation controller_association) const {
+  // TODO: Can we make the source_bridge and controller_association inherent to the class instead of passed as
+  // arguments?
+  uint8_t packetBytes[PACKET_MAX_SIZE];
+  packetBytes[0] = 0;  // Reset control byte before starting
+
+  // Drain UART until we see a control byte (times out after 100ms in UARTComponent)
+  while (uart_comp.available() >= PACKET_HEADER_SIZE && uart_comp.read_byte(&packetBytes[0])) {
+    if (packetBytes[0] == BYTE_CONTROL)
+      break;
+    // TODO: If the serial is all garbage, this may never stop-- we should have our own timeout
+  }
+
+  // If we never found a control byte, we didn't receive a packet
+  if (packetBytes[0] != BYTE_CONTROL) {
+    return nullopt;
+  }
+
+  // Read the header
+  uart_comp.read_array(&packetBytes[1], PACKET_HEADER_SIZE - 1);
+
+  // Read payload + checksum
+  uint8_t payloadSize = packetBytes[PACKET_HEADER_INDEX_PAYLOAD_LENGTH];
+  uart_comp.read_array(&packetBytes[PACKET_HEADER_SIZE], payloadSize + 1);
+
+  return RawPacket(packetBytes, PACKET_HEADER_SIZE + payloadSize + 1, source_bridge, controller_association);
+}
+
+template<class P> void MUARTBridge::processRawPacket(RawPacket &pkt, bool expectResponse) const {
+  P packet = P(std::move(pkt));
+  packet.setResponseExpected(expectResponse);
+  pkt_processor.processPacket(packet);
+}
+
+void MUARTBridge::classifyAndProcessRawPacket(RawPacket &pkt) const {
+  // Figure out how to do this without a static_cast?
+  switch (static_cast<PacketType>(pkt.getPacketType())) {
+    case PacketType::connect_request:
+      processRawPacket<ConnectRequestPacket>(pkt, true);
+      break;
+    case PacketType::connect_response:
+      processRawPacket<ConnectResponsePacket>(pkt, false);
+      break;
+
+    case PacketType::extended_connect_request:
+      processRawPacket<ExtendedConnectRequestPacket>(pkt, true);
+      break;
+    case PacketType::extended_connect_response:
+      processRawPacket<ExtendedConnectResponsePacket>(pkt, false);
+      break;
+
+    case PacketType::get_request:
+      processRawPacket<GetRequestPacket>(pkt, true);
+      break;
+    case PacketType::get_response:
+      switch (static_cast<GetCommand>(pkt.getCommand())) {
+        case GetCommand::settings:
+          processRawPacket<SettingsGetResponsePacket>(pkt, false);
+          break;
+        case GetCommand::current_temp:
+          processRawPacket<CurrentTempGetResponsePacket>(pkt, false);
+          break;
+        case GetCommand::error_info:
+          processRawPacket<ErrorStateGetResponsePacket>(pkt, false);
+          break;
+        case GetCommand::standby:
+          processRawPacket<StandbyGetResponsePacket>(pkt, false);
+          break;
+        case GetCommand::status:
+          processRawPacket<StatusGetResponsePacket>(pkt, false);
+          break;
+        case GetCommand::a_9:
+          processRawPacket<A9GetRequestPacket>(pkt, false);
+          break;
+        default:
+          processRawPacket<Packet>(pkt, false);
+      }
+      break;
+    case PacketType::set_request:
+      switch (static_cast<SetCommand>(pkt.getCommand())) {
+        case SetCommand::remote_temperature:
+          processRawPacket<RemoteTemperatureSetRequestPacket>(pkt, true);
+          break;
+        case SetCommand::settings:
+          processRawPacket<SettingsSetRequestPacket>(pkt, true);
+          break;
+        case SetCommand::thermostat_hello:
+          processRawPacket<ThermostatHelloRequestPacket>(pkt, false);
+          break;
+        default:
+          processRawPacket<Packet>(pkt, true);
+      }
+      break;
+    case PacketType::set_response:
+      processRawPacket<SetResponsePacket>(pkt, false);
+      break;
+
+    default:
+      processRawPacket<Packet>(pkt, true);  // If we get an unknown packet from the thermostat, expect a response
+  }
+}
+
+}  // namespace mitsubishi_uart
+}  // namespace esphome

--- a/esphome/components/mitsubishi_uart/muart_bridge.h
+++ b/esphome/components/mitsubishi_uart/muart_bridge.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "esphome/components/uart/uart.h"
+#include "muart_packet.h"
+#include "queue"
+
+namespace esphome {
+namespace mitsubishi_uart {
+
+static const char *BRIDGE_TAG = "muart_bridge";
+static const uint32_t RESPONSE_TIMEOUT_MS = 3000;  // Maximum amount of time to wait for an expected response packet
+/* Maximum number of packets allowed to be queued for sending.  In some circumstances the equipment response
+time can be very slow and packets would queue up faster than they were being received.  TODO: Not sure what size this
+should be, 4ish should be enough for almost all situations, so 8 seems plenty.*/
+static const size_t MAX_QUEUE_SIZE = 8;
+
+// A UARTComponent wrapper to send and receieve packets
+class MUARTBridge {
+ public:
+  MUARTBridge(uart::UARTComponent *uart_component, PacketProcessor *packet_processor);
+
+  // Enqueues a packet to be sent
+  void sendPacket(const Packet &packetToSend);
+
+  // Checks for incoming packets, processes them, sends queued packets
+  virtual void loop() = 0;
+
+ protected:
+  const optional<RawPacket> receiveRawPacket(const SourceBridge source_bridge,
+                                             const ControllerAssociation controller_association) const;
+  void writeRawPacket(const RawPacket &pkt) const;
+  template<class P> void processRawPacket(RawPacket &pkt, bool expectResponse = true) const;
+  void classifyAndProcessRawPacket(RawPacket &pkt) const;
+
+  uart::UARTComponent &uart_comp;
+  PacketProcessor &pkt_processor;
+  std::queue<Packet> pkt_queue;
+  optional<Packet> packetAwaitingResponse = nullopt;
+  uint32_t packet_sent_millis;
+};
+
+class HeatpumpBridge : public MUARTBridge {
+ public:
+  using MUARTBridge::MUARTBridge;
+  void loop() override;
+};
+
+class ThermostatBridge : public MUARTBridge {
+ public:
+  using MUARTBridge::MUARTBridge;
+  // ThermostatBridge(uart::UARTComponent &uart_component, PacketProcessor &packet_processor) :
+  // MUARTBridge(uart_component, packet_processor){};
+  void loop() override;
+};
+
+}  // namespace mitsubishi_uart
+}  // namespace esphome

--- a/esphome/components/mitsubishi_uart/muart_packet-derived.cpp
+++ b/esphome/components/mitsubishi_uart/muart_packet-derived.cpp
@@ -1,0 +1,303 @@
+#include "muart_packet.h"
+#include "muart_utils.h"
+#include "mitsubishi_uart.h"
+
+namespace esphome {
+namespace mitsubishi_uart {
+
+// Packet to_strings()
+
+std::string ConnectRequestPacket::to_string() const { return ("Connect Request: " + Packet::to_string()); }
+std::string ConnectResponsePacket::to_string() const { return ("Connect Response: " + Packet::to_string()); }
+std::string ExtendedConnectResponsePacket::to_string() const {
+  return ("Extended Connect Response: " + Packet::to_string() + CONSOLE_COLOR_PURPLE +
+          "\n HeatDisabled:" + (isHeatDisabled() ? "Yes" : "No") + " SupportsVane:" + (supportsVane() ? "Yes" : "No") +
+          " SupportsVaneSwing:" + (supportsVaneSwing() ? "Yes" : "No")
+
+          + " DryDisabled:" + (isDryDisabled() ? "Yes" : "No") + " FanDisabled:" + (isFanDisabled() ? "Yes" : "No") +
+          " ExtTempRange:" + (hasExtendedTemperatureRange() ? "Yes" : "No") +
+          " AutoFanDisabled:" + (autoFanSpeedDisabled() ? "Yes" : "No") +
+          " InstallerSettings:" + (supportsInstallerSettings() ? "Yes" : "No") +
+          " TestMode:" + (supportsTestMode() ? "Yes" : "No") + " DryTemp:" + (supportsDryTemperature() ? "Yes" : "No")
+
+          + " StatusDisplay:" + (hasStatusDisplay() ? "Yes" : "No")
+
+          + "\n CoolDrySetpoint:" + std::to_string(getMinCoolDrySetpoint()) + "/" +
+          std::to_string(getMaxCoolDrySetpoint()) + " HeatSetpoint:" + std::to_string(getMinHeatingSetpoint()) + "/" +
+          std::to_string(getMaxHeatingSetpoint()) + " AutoSetpoint:" + std::to_string(getMinAutoSetpoint()) + "/" +
+          std::to_string(getMaxAutoSetpoint()) + " FanSpeeds:" + std::to_string(getSupportedFanSpeeds()));
+}
+std::string CurrentTempGetResponsePacket::to_string() const {
+  return ("Current Temp Response: " + Packet::to_string() + CONSOLE_COLOR_PURPLE +
+          "\n Temp:" + std::to_string(getCurrentTemp()));
+}
+std::string SettingsGetResponsePacket::to_string() const {
+  return ("Settings Response: " + Packet::to_string() + CONSOLE_COLOR_PURPLE + "\n Fan:" + format_hex(getFan()) +
+          " Mode:" + format_hex(getMode()) + " Power:" +
+          (getPower() == 3  ? "Test"
+           : getPower() > 0 ? "On"
+                            : "Off") +
+          " TargetTemp:" + std::to_string(getTargetTemp()) + " Vane:" + format_hex(getVane()) +
+          " HVane:" + format_hex(getHorizontalVane()) + (getHorizontalVaneMSB() ? " (MSB Set)" : "") +
+          "\n PowerLock:" + (lockedPower() ? "Yes" : "No") + " ModeLock:" + (lockedMode() ? "Yes" : "No") +
+          " TempLock:" + (lockedTemp() ? "Yes" : "No"));
+}
+std::string StandbyGetResponsePacket::to_string() const {
+  return ("Standby Response: " + Packet::to_string() + CONSOLE_COLOR_PURPLE +
+          "\n ServiceFilter:" + (serviceFilter() ? "Yes" : "No") + " Defrost:" + (inDefrost() ? "Yes" : "No") +
+          " HotAdjust:" + (inHotAdjust() ? "Yes" : "No") + " Standby:" + (inStandby() ? "Yes" : "No") +
+          " ActualFan:" + ACTUAL_FAN_SPEED_NAMES[getActualFanSpeed()] + " (" + std::to_string(getActualFanSpeed()) +
+          ")" + " AutoMode:" + format_hex(getAutoMode()));
+}
+std::string StatusGetResponsePacket::to_string() const {
+  return ("Status Response: " + Packet::to_string() + CONSOLE_COLOR_PURPLE + "\n CompressorFrequency: " +
+          std::to_string(getCompressorFrequency()) + " Operating: " + (getOperating() ? "Yes" : "No"));
+}
+std::string ErrorStateGetResponsePacket::to_string() const {
+  return ("Error State Response: " + Packet::to_string() + CONSOLE_COLOR_PURPLE +
+          "\n Error State: " + (errorPresent() ? "Yes" : "No") + " ErrorCode: " + format_hex(getErrorCode()) +
+          " ShortCode: " + getShortCode() + "(" + format_hex(getRawShortCode()) + ")");
+}
+std::string RemoteTemperatureSetRequestPacket::to_string() const {
+  return ("Remote Temp Set Request: " + Packet::to_string() + CONSOLE_COLOR_PURPLE +
+          "\n Temp:" + std::to_string(getRemoteTemperature()));
+}
+
+std::string ThermostatHelloRequestPacket::to_string() const {
+  return ("Thermostat Hello: " + Packet::to_string() + CONSOLE_COLOR_PURPLE + "\n Model: " + getThermostatModel() +
+          " Serial: " + getThermostatSerial() + " Version: " + getThermostatVersionString());
+}
+
+// TODO: Are there function implementations for packets in the .h file? (Yes)  Should they be here?
+
+// SettingsSetRequestPacket functions
+
+void SettingsSetRequestPacket::addSettingsFlag(const SETTING_FLAG flagToAdd) { addFlag(flagToAdd); }
+
+void SettingsSetRequestPacket::addSettingsFlag2(const SETTING_FLAG2 flag2ToAdd) { addFlag2(flag2ToAdd); }
+
+SettingsSetRequestPacket &SettingsSetRequestPacket::setPower(const bool isOn) {
+  pkt_.setPayloadByte(PLINDEX_POWER, isOn ? 0x01 : 0x00);
+  addSettingsFlag(SF_POWER);
+  return *this;
+}
+
+SettingsSetRequestPacket &SettingsSetRequestPacket::setMode(const MODE_BYTE mode) {
+  pkt_.setPayloadByte(PLINDEX_MODE, mode);
+  addSettingsFlag(SF_MODE);
+  return *this;
+}
+
+SettingsSetRequestPacket &SettingsSetRequestPacket::setTargetTemperature(const float temperatureDegressC) {
+  if (temperatureDegressC < 63.5 && temperatureDegressC > -64.0) {
+    pkt_.setPayloadByte(PLINDEX_TARGET_TEMPERATURE, MUARTUtils::DegCToTempScaleA(temperatureDegressC));
+    pkt_.setPayloadByte(PLINDEX_TARGET_TEMPERATURE_CODE, MUARTUtils::DegCToLegacyTargetTemp(temperatureDegressC));
+
+    // TODO: while spawning a warning here is fine, we should (a) only actually send that warning if the system can't
+    //       support this setpoint, and (b) clamp the setpoint to the known-acceptable values.
+    // The utility class will already clamp this for us, so we only need to worry about the warning.
+    if (temperatureDegressC < 16 || temperatureDegressC > 31.5) {
+      ESP_LOGW(PTAG, "Target temp %f is out of range for the legacy temp scale. This may be a problem on older units.",
+               temperatureDegressC);
+    }
+
+    addSettingsFlag(SF_TARGET_TEMPERATURE);
+  } else {
+    ESP_LOGW(PTAG, "Target temp %f is outside valid range - target temperature not set!", temperatureDegressC);
+  }
+
+  return *this;
+}
+SettingsSetRequestPacket &SettingsSetRequestPacket::setFan(const FAN_BYTE fan) {
+  pkt_.setPayloadByte(PLINDEX_FAN, fan);
+  addSettingsFlag(SF_FAN);
+  return *this;
+}
+
+SettingsSetRequestPacket &SettingsSetRequestPacket::setVane(const VANE_BYTE vane) {
+  pkt_.setPayloadByte(PLINDEX_VANE, vane);
+  addSettingsFlag(SF_VANE);
+  return *this;
+}
+
+SettingsSetRequestPacket &SettingsSetRequestPacket::setHorizontalVane(const HORIZONTAL_VANE_BYTE horizontal_vane) {
+  pkt_.setPayloadByte(PLINDEX_HORIZONTAL_VANE, horizontal_vane);
+  addSettingsFlag2(SF2_HORIZONTAL_VANE);
+  return *this;
+}
+
+// SettingsGetResponsePacket functions
+float SettingsGetResponsePacket::getTargetTemp() const {
+  uint8_t enhancedRawTemp = pkt_.getPayloadByte(PLINDEX_TARGETTEMP);
+
+  if (enhancedRawTemp == 0x00) {
+    uint8_t legacyRawTemp = pkt_.getPayloadByte(PLINDEX_TARGETTEMP_LEGACY);
+    return MUARTUtils::LegacyTargetTempToDegC(legacyRawTemp);
+  }
+
+  return MUARTUtils::TempScaleAToDegC(enhancedRawTemp);
+}
+
+// RemoteTemperatureSetRequestPacket functions
+
+float RemoteTemperatureSetRequestPacket::getRemoteTemperature() const {
+  uint8_t rawTempA = pkt_.getPayloadByte(PLINDEX_REMOTE_TEMPERATURE);
+
+  if (rawTempA == 0) {
+    uint8_t rawTempLegacy = pkt_.getPayloadByte(PLINDEX_LEGACY_REMOTE_TEMPERATURE);
+    return MUARTUtils::LegacyRoomTempToDegC(rawTempLegacy);
+  }
+
+  return MUARTUtils::TempScaleAToDegC(rawTempA);
+}
+
+RemoteTemperatureSetRequestPacket &RemoteTemperatureSetRequestPacket::setRemoteTemperature(float temperatureDegressC) {
+  if (temperatureDegressC < 63.5 && temperatureDegressC > -64.0) {
+    pkt_.setPayloadByte(PLINDEX_REMOTE_TEMPERATURE, MUARTUtils::DegCToTempScaleA(temperatureDegressC));
+    pkt_.setPayloadByte(PLINDEX_LEGACY_REMOTE_TEMPERATURE, MUARTUtils::DegCToLegacyRoomTemp(temperatureDegressC));
+    setFlags(0x01);  // Set flags to say we're providing the temperature
+  } else {
+    ESP_LOGW(PTAG, "Remote temp %f is outside valid range.", temperatureDegressC);
+  }
+  return *this;
+}
+RemoteTemperatureSetRequestPacket &RemoteTemperatureSetRequestPacket::useInternalTemperature() {
+  setFlags(0x00);  // Set flags to say to use internal temperature
+  return *this;
+}
+
+// CurrentTempGetResponsePacket functions
+float CurrentTempGetResponsePacket::getCurrentTemp() const {
+  uint8_t enhancedRawTemp = pkt_.getPayloadByte(PLINDEX_CURRENTTEMP);
+
+  // TODO: Figure out how to handle "out of range" issues here.
+  if (enhancedRawTemp == 0) {
+    uint8_t legacyRawTemp = pkt_.getPayloadByte(PLINDEX_CURRENTTEMP_LEGACY);
+    return MUARTUtils::LegacyRoomTempToDegC(legacyRawTemp);
+  }
+
+  return MUARTUtils::TempScaleAToDegC(enhancedRawTemp);
+}
+
+// ThermostatHelloRequestPacket functions
+std::string ThermostatHelloRequestPacket::getThermostatModel() const {
+  return MUARTUtils::DecodeNBitString((pkt_.getBytes() + 1), 3, 6);
+}
+
+std::string ThermostatHelloRequestPacket::getThermostatSerial() const {
+  return MUARTUtils::DecodeNBitString((pkt_.getBytes() + 4), 8, 6);
+}
+
+std::string ThermostatHelloRequestPacket::getThermostatVersionString() const {
+  char buf[16];
+  sprintf(buf, "%02d.%02d.%02d", pkt_.getPayloadByte(13), pkt_.getPayloadByte(14), pkt_.getPayloadByte(15));
+
+  return buf;
+}
+
+// ErrorStateGetResponsePacket functions
+std::string ErrorStateGetResponsePacket::getShortCode() const {
+  const char *upperAlphabet = "AbEFJLPU";
+  const char *lowerAlphabet = "0123456789ABCDEFOHJLPU";
+  const uint8_t errorCode = this->getRawShortCode();
+
+  uint8_t lowBits = errorCode & 0x1F;
+  if (lowBits > 0x15) {
+    char buf[7];
+    sprintf(buf, "ERR_%x", errorCode);
+    return buf;
+  }
+
+  return {upperAlphabet[(errorCode & 0xE0) >> 5], lowerAlphabet[lowBits]};
+}
+
+// ExtendedConnectResponsePacket functions
+uint8_t ExtendedConnectResponsePacket::getSupportedFanSpeeds() const {
+  uint8_t raw_value = ((pkt_.getPayloadByte(7) & 0x10) >> 2) + ((pkt_.getPayloadByte(8) & 0x08) >> 2) +
+                      ((pkt_.getPayloadByte(9) & 0x02) >> 1);
+
+  switch (raw_value) {
+    case 1:
+    case 2:
+    case 4:
+      return raw_value;
+    case 0:
+      return 3;
+    case 6:
+      return 5;
+
+    default:
+      ESP_LOGW(PACKETS_TAG, "Unexpected supported fan speeds: %i", raw_value);
+      return 0;  // TODO: Depending on how this is used, it might be more useful to just return 3 and hope for the best
+  }
+}
+
+climate::ClimateTraits ExtendedConnectResponsePacket::asTraits() const {
+  auto ct = climate::ClimateTraits();
+
+  // always enabled
+  ct.add_supported_mode(climate::CLIMATE_MODE_COOL);
+  ct.add_supported_mode(climate::CLIMATE_MODE_OFF);
+
+  if (!this->isHeatDisabled())
+    ct.add_supported_mode(climate::CLIMATE_MODE_HEAT);
+  if (!this->isDryDisabled())
+    ct.add_supported_mode(climate::CLIMATE_MODE_DRY);
+  if (!this->isFanDisabled())
+    ct.add_supported_mode(climate::CLIMATE_MODE_FAN_ONLY);
+
+  if (this->supportsVaneSwing()) {
+    ct.add_supported_swing_mode(climate::CLIMATE_SWING_OFF);
+
+    if (this->supportsVane() && this->supportsHVane())
+      ct.add_supported_swing_mode(climate::CLIMATE_SWING_BOTH);
+    if (this->supportsVane())
+      ct.add_supported_swing_mode(climate::CLIMATE_SWING_VERTICAL);
+    if (this->supportsHVane())
+      ct.add_supported_swing_mode(climate::CLIMATE_SWING_HORIZONTAL);
+  }
+
+  ct.set_visual_min_temperature(std::min(this->getMinCoolDrySetpoint(), this->getMinHeatingSetpoint()));
+  ct.set_visual_max_temperature(std::max(this->getMaxCoolDrySetpoint(), this->getMaxHeatingSetpoint()));
+
+  // TODO: Figure out what these states *actually* map to so we aren't sending bad data.
+  // This is probably a dynamic map, so the setter will need to be aware of things.
+  switch (this->getSupportedFanSpeeds()) {
+    case 1:
+      ct.set_supported_fan_modes({climate::CLIMATE_FAN_HIGH});
+      break;
+    case 2:
+      ct.set_supported_fan_modes({climate::CLIMATE_FAN_LOW, climate::CLIMATE_FAN_HIGH});
+      break;
+    case 3:
+      ct.set_supported_fan_modes({climate::CLIMATE_FAN_LOW, climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH});
+      break;
+    case 4:
+      ct.set_supported_fan_modes({
+          climate::CLIMATE_FAN_QUIET,
+          climate::CLIMATE_FAN_LOW,
+          climate::CLIMATE_FAN_MEDIUM,
+          climate::CLIMATE_FAN_HIGH,
+      });
+      break;
+    case 5:
+      ct.set_supported_fan_modes({
+          climate::CLIMATE_FAN_QUIET,
+          climate::CLIMATE_FAN_LOW,
+          climate::CLIMATE_FAN_MEDIUM,
+          climate::CLIMATE_FAN_HIGH,
+      });
+      ct.add_supported_custom_fan_mode("Very High");
+      break;
+    default:
+      // no-op, don't set a fan mode.
+      break;
+  }
+  if (!this->autoFanSpeedDisabled())
+    ct.add_supported_fan_mode(climate::CLIMATE_FAN_AUTO);
+
+  return ct;
+}
+
+}  // namespace mitsubishi_uart
+}  // namespace esphome

--- a/esphome/components/mitsubishi_uart/muart_packet.cpp
+++ b/esphome/components/mitsubishi_uart/muart_packet.cpp
@@ -1,0 +1,77 @@
+#include "muart_packet.h"
+
+namespace esphome {
+namespace mitsubishi_uart {
+
+// Creates an empty packet
+Packet::Packet() {
+  // TODO: Is this okay?
+}
+
+// std::string Packet::to_string() const {
+//   return format_hex_pretty(&pkt_.getBytes()[0], pkt_.getLength());
+// }
+
+static char format_hex_pretty_char(uint8_t v) { return v >= 10 ? 'A' + (v - 10) : '0' + v; }
+
+std::string Packet::to_string() const {
+  // Based on `format_hex_pretty` from ESPHome
+  if (pkt_.getLength() < PACKET_HEADER_SIZE)
+    return "";
+  std::stringstream stream;
+
+  stream << CONSOLE_COLOR_CYAN;  // Cyan
+  stream << '[';
+
+  for (size_t i = 0; i < PACKET_HEADER_SIZE; i++) {
+    if (i == 1) {
+      stream << CONSOLE_COLOR_CYAN_BOLD;
+    }
+    stream << format_hex_pretty_char((pkt_.getBytes()[i] & 0xF0) >> 4);
+    stream << format_hex_pretty_char(pkt_.getBytes()[i] & 0x0F);
+    if (i < PACKET_HEADER_SIZE - 1) {
+      stream << '.';
+    }
+    if (i == 1) {
+      stream << CONSOLE_COLOR_CYAN;
+    }
+  }
+  // Header close-bracket
+  stream << ']';
+  stream << CONSOLE_COLOR_WHITE;  // White
+
+  // Payload
+  for (size_t i = PACKET_HEADER_SIZE; i < pkt_.getLength() - 1; i++) {
+    stream << format_hex_pretty_char((pkt_.getBytes()[i] & 0xF0) >> 4);
+    stream << format_hex_pretty_char(pkt_.getBytes()[i] & 0x0F);
+    if (i < pkt_.getLength() - 2) {
+      stream << '.';
+    }
+  }
+
+  // Space
+  stream << ' ';
+  stream << CONSOLE_COLOR_GREEN;  // Green
+
+  // Checksum
+  stream << format_hex_pretty_char((pkt_.getBytes()[pkt_.getLength() - 1] & 0xF0) >> 4);
+  stream << format_hex_pretty_char(pkt_.getBytes()[pkt_.getLength() - 1] & 0x0F);
+
+  stream << CONSOLE_COLOR_NONE;  // Reset
+
+  return stream.str();
+}
+
+void Packet::setFlags(const uint8_t flagValue) { pkt_.setPayloadByte(PLINDEX_FLAGS, flagValue); }
+
+// Adds a flag (ONLY APPLICABLE FOR SOME COMMANDS)
+void Packet::addFlag(const uint8_t flagToAdd) {
+  pkt_.setPayloadByte(PLINDEX_FLAGS, pkt_.getPayloadByte(PLINDEX_FLAGS) | flagToAdd);
+}
+// Adds a flag2 (ONLY APPLICABLE FOR SOME COMMANDS)
+void Packet::addFlag2(const uint8_t flag2ToAdd) {
+  pkt_.setPayloadByte(PLINDEX_FLAGS2, pkt_.getPayloadByte(PLINDEX_FLAGS2) | flag2ToAdd);
+}
+
+}  // namespace mitsubishi_uart
+}  // namespace esphome

--- a/esphome/components/mitsubishi_uart/muart_packet.h
+++ b/esphome/components/mitsubishi_uart/muart_packet.h
@@ -1,0 +1,416 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/climate/climate.h"
+#include "esphome/components/uart/uart.h"
+#include "muart_rawpacket.h"
+#include "muart_utils.h"
+#include <sstream>
+
+namespace esphome {
+namespace mitsubishi_uart {
+static const char *PACKETS_TAG = "mitsubishi_uart.packets";
+#define LOGPACKET(packet, direction) \
+  ESP_LOGD(PACKETS_TAG, "%s [%02x] %s", direction, packet.getPacketType(), packet.to_string().c_str());
+
+#define CONSOLE_COLOR_NONE "\033[0m"
+#define CONSOLE_COLOR_GREEN "\033[0;32m"
+#define CONSOLE_COLOR_PURPLE "\033[0;35m"
+#define CONSOLE_COLOR_CYAN "\033[0;36m"
+#define CONSOLE_COLOR_CYAN_BOLD "\033[1;36m"
+#define CONSOLE_COLOR_WHITE "\033[0;37m"
+
+class PacketProcessor;
+
+// Generic Base Packet wrapper over RawPacket
+class Packet {
+ public:
+  Packet(RawPacket &&pkt)
+      : pkt_(std::move(pkt)){};  // TODO: Confirm this needs std::move if call to constructor ALSO has move
+  Packet();                      // For optional<> construction
+
+  // Returns a (more) human readable string of the packet
+  virtual std::string to_string() const;
+
+  // Is a response packet expected when this packet is sent.  Defaults to true since
+  // most requests receive a response.
+  bool isResponseExpected() const { return responseExpected; };
+  void setResponseExpected(bool expectResponse) { responseExpected = expectResponse; };
+
+  // Passthrough methods to RawPacket
+  RawPacket &rawPacket() { return pkt_; };
+  uint8_t getPacketType() const { return pkt_.getPacketType(); }
+  bool isChecksumValid() const { return pkt_.isChecksumValid(); };
+
+  // Returns flags (ONLY APPLICABLE FOR SOME COMMANDS)
+  uint8_t getFlags() const { return pkt_.getPayloadByte(PLINDEX_FLAGS); }
+  // Sets flags (ONLY APPLICABLE FOR SOME COMMANDS)
+  void setFlags(const uint8_t flagValue);
+  // Adds a flag (ONLY APPLICABLE FOR SOME COMMANDS)
+  void addFlag(const uint8_t flagToAdd);
+  // Adds a flag2 (ONLY APPLICABLE FOR SOME COMMANDS)
+  void addFlag2(const uint8_t flag2ToAdd);
+
+  SourceBridge getSourceBridge() const { return pkt_.getSourceBridge(); }
+  ControllerAssociation getControllerAssociation() const { return pkt_.getControllerAssociation(); }
+
+ protected:
+  static const int PLINDEX_FLAGS = 1;
+  static const int PLINDEX_FLAGS2 = 2;
+
+  RawPacket pkt_;
+
+ private:
+  bool responseExpected = true;
+};
+
+////
+// Connect
+////
+class ConnectRequestPacket : public Packet {
+ public:
+  using Packet::Packet;
+  static ConnectRequestPacket &instance() {
+    static ConnectRequestPacket INSTANCE;
+    return INSTANCE;
+  }
+
+  std::string to_string() const override;
+
+ private:
+  ConnectRequestPacket() : Packet(RawPacket(PacketType::connect_request, 2)) {
+    pkt_.setPayloadByte(0, 0xca);
+    pkt_.setPayloadByte(1, 0x01);
+  }
+};
+
+class ConnectResponsePacket : public Packet {
+ public:
+  using Packet::Packet;
+  std::string to_string() const override;
+};
+
+////
+// Extended Connect
+////
+class ExtendedConnectRequestPacket : public Packet {
+ public:
+  static ExtendedConnectRequestPacket &instance() {
+    static ExtendedConnectRequestPacket INSTANCE;
+    return INSTANCE;
+  }
+  using Packet::Packet;
+
+ private:
+  ExtendedConnectRequestPacket() : Packet(RawPacket(PacketType::extended_connect_request, 1)) {
+    pkt_.setPayloadByte(0, 0xc9);
+  }
+};
+
+class ExtendedConnectResponsePacket : public Packet {
+  using Packet::Packet;
+
+ public:
+  // Byte 7
+  bool isHeatDisabled() const { return pkt_.getPayloadByte(7) & 0x02; }
+  bool supportsVane() const { return pkt_.getPayloadByte(7) & 0x20; }
+  bool supportsVaneSwing() const { return pkt_.getPayloadByte(7) & 0x40; }
+
+  // Byte 8
+  bool isDryDisabled() const { return pkt_.getPayloadByte(8) & 0x01; }
+  bool isFanDisabled() const { return pkt_.getPayloadByte(8) & 0x02; }
+  bool hasExtendedTemperatureRange() const { return pkt_.getPayloadByte(8) & 0x04; }
+  bool autoFanSpeedDisabled() const { return pkt_.getPayloadByte(8) & 0x10; }
+  bool supportsInstallerSettings() const { return pkt_.getPayloadByte(8) & 0x20; }
+  bool supportsTestMode() const { return pkt_.getPayloadByte(8) & 0x40; }
+  bool supportsDryTemperature() const { return pkt_.getPayloadByte(8) & 0x80; }
+
+  // Byte 9
+  bool hasStatusDisplay() const { return pkt_.getPayloadByte(9) & 0x01; }
+
+  // Bytes 10-15
+  float getMinCoolDrySetpoint() const { return MUARTUtils::TempScaleAToDegC(pkt_.getPayloadByte(10)); }
+  float getMaxCoolDrySetpoint() const { return MUARTUtils::TempScaleAToDegC(pkt_.getPayloadByte(11)); }
+  float getMinHeatingSetpoint() const { return MUARTUtils::TempScaleAToDegC(pkt_.getPayloadByte(12)); }
+  float getMaxHeatingSetpoint() const { return MUARTUtils::TempScaleAToDegC(pkt_.getPayloadByte(13)); }
+  float getMinAutoSetpoint() const { return MUARTUtils::TempScaleAToDegC(pkt_.getPayloadByte(14)); }
+  float getMaxAutoSetpoint() const { return MUARTUtils::TempScaleAToDegC(pkt_.getPayloadByte(15)); }
+
+  // Things that have to exist, but we don't know where yet.
+  bool supportsHVane() const { return true; }
+
+  // Fan Speeds TODO: Probably move this to .cpp?
+  uint8_t getSupportedFanSpeeds() const;
+
+  // Convert a temperature response into ClimateTraits. This will *not* include library-provided features.
+  // This will also not handle things like MHK2 humidity detection.
+  climate::ClimateTraits asTraits() const;
+
+  std::string to_string() const override;
+};
+
+////
+// Get
+////
+class GetRequestPacket : public Packet {
+ public:
+  static GetRequestPacket &getSettingsInstance() {
+    static GetRequestPacket INSTANCE = GetRequestPacket(GetCommand::settings);
+    return INSTANCE;
+  }
+  static GetRequestPacket &getCurrentTempInstance() {
+    static GetRequestPacket INSTANCE = GetRequestPacket(GetCommand::current_temp);
+    return INSTANCE;
+  }
+  static GetRequestPacket &getStatusInstance() {
+    static GetRequestPacket INSTANCE = GetRequestPacket(GetCommand::standby);
+    return INSTANCE;
+  }
+  static GetRequestPacket &getStandbyInstance() {
+    static GetRequestPacket INSTANCE = GetRequestPacket(GetCommand::status);
+    return INSTANCE;
+  }
+  static GetRequestPacket &getErrorInfoInstance() {
+    static GetRequestPacket INSTANCE = GetRequestPacket(GetCommand::error_info);
+    return INSTANCE;
+  }
+  using Packet::Packet;
+
+ private:
+  GetRequestPacket(GetCommand get_command) : Packet(RawPacket(PacketType::get_request, 1)) {
+    pkt_.setPayloadByte(0, static_cast<uint8_t>(get_command));
+  }
+};
+
+class SettingsGetResponsePacket : public Packet {
+  static const int PLINDEX_POWER = 3;
+  static const int PLINDEX_MODE = 4;
+  static const int PLINDEX_TARGETTEMP_LEGACY = 5;
+  static const int PLINDEX_FAN = 6;
+  static const int PLINDEX_VANE = 7;
+  static const int PLINDEX_PROHIBITFLAGS = 8;
+  static const int PLINDEX_HVANE = 10;
+  static const int PLINDEX_TARGETTEMP = 11;
+  using Packet::Packet;
+
+ public:
+  uint8_t getPower() const { return pkt_.getPayloadByte(PLINDEX_POWER); }
+  uint8_t getMode() const { return pkt_.getPayloadByte(PLINDEX_MODE); }
+  uint8_t getFan() const { return pkt_.getPayloadByte(PLINDEX_FAN); }
+  uint8_t getVane() const { return pkt_.getPayloadByte(PLINDEX_VANE); }
+  bool lockedPower() const { return pkt_.getPayloadByte(PLINDEX_PROHIBITFLAGS) & 0x01; }
+  bool lockedMode() const { return pkt_.getPayloadByte(PLINDEX_PROHIBITFLAGS) & 0x02; }
+  bool lockedTemp() const { return pkt_.getPayloadByte(PLINDEX_PROHIBITFLAGS) & 0x04; }
+  uint8_t getHorizontalVane() const { return pkt_.getPayloadByte(PLINDEX_HVANE) & 0x7F; }
+  bool getHorizontalVaneMSB() const { return pkt_.getPayloadByte(PLINDEX_HVANE) & 0x80; }
+
+  float getTargetTemp() const;
+
+  std::string to_string() const override;
+};
+
+class CurrentTempGetResponsePacket : public Packet {
+  static const int PLINDEX_CURRENTTEMP_LEGACY = 3;
+  static const int PLINDEX_CURRENTTEMP = 6;
+  using Packet::Packet;
+
+ public:
+  float getCurrentTemp() const;
+  std::string to_string() const override;
+};
+
+class StatusGetResponsePacket : public Packet {
+  static const int PLINDEX_COMPRESSOR_FREQUENCY = 3;
+  static const int PLINDEX_OPERATING = 4;
+
+  using Packet::Packet;
+
+ public:
+  uint8_t getCompressorFrequency() const { return pkt_.getPayloadByte(PLINDEX_COMPRESSOR_FREQUENCY); }
+  bool getOperating() const { return pkt_.getPayloadByte(PLINDEX_OPERATING); }
+  std::string to_string() const override;
+};
+
+class StandbyGetResponsePacket : public Packet {
+  static const int PLINDEX_STATUSFLAGS = 3;
+  static const int PLINDEX_ACTUALFAN = 4;
+  static const int PLINDEX_AUTOMODE = 5;
+  using Packet::Packet;
+
+ public:
+  bool serviceFilter() const { return pkt_.getPayloadByte(PLINDEX_STATUSFLAGS) & 0x01; }
+  bool inDefrost() const { return pkt_.getPayloadByte(PLINDEX_STATUSFLAGS) & 0x02; }
+  bool inHotAdjust() const { return pkt_.getPayloadByte(PLINDEX_STATUSFLAGS) & 0x04; }
+  bool inStandby() const { return pkt_.getPayloadByte(PLINDEX_STATUSFLAGS) & 0x08; }
+  uint8_t getActualFanSpeed() const { return pkt_.getPayloadByte(PLINDEX_ACTUALFAN); }
+  uint8_t getAutoMode() const { return pkt_.getPayloadByte(PLINDEX_AUTOMODE); }
+  std::string to_string() const override;
+};
+
+class ErrorStateGetResponsePacket : public Packet {
+  using Packet::Packet;
+
+ public:
+  uint16_t getErrorCode() const { return pkt_.getPayloadByte(4) << 8 | pkt_.getPayloadByte(5); }
+  uint8_t getRawShortCode() const { return pkt_.getPayloadByte(6); }
+  std::string getShortCode() const;
+
+  bool errorPresent() const { return getErrorCode() != 0x8000 || getRawShortCode() != 0x00; }
+
+  std::string to_string() const override;
+};
+
+////
+// Set
+////
+
+class SettingsSetRequestPacket : public Packet {
+  static const int PLINDEX_POWER = 3;
+  static const int PLINDEX_MODE = 4;
+  static const int PLINDEX_TARGET_TEMPERATURE_CODE = 5;
+  static const int PLINDEX_FAN = 6;
+  static const int PLINDEX_VANE = 7;
+  static const int PLINDEX_HORIZONTAL_VANE = 13;
+  static const int PLINDEX_TARGET_TEMPERATURE = 14;
+
+  enum SETTING_FLAG : uint8_t {
+    SF_POWER = 0x01,
+    SF_MODE = 0x02,
+    SF_TARGET_TEMPERATURE = 0x04,
+    SF_FAN = 0x08,
+    SF_VANE = 0x10
+  };
+
+  enum SETTING_FLAG2 : uint8_t {
+    SF2_HORIZONTAL_VANE = 0x01,
+  };
+
+ public:
+  enum MODE_BYTE : uint8_t {
+    MODE_BYTE_HEAT = 0x01,
+    MODE_BYTE_DRY = 0x02,
+    MODE_BYTE_COOL = 0x03,
+    MODE_BYTE_FAN = 0x07,
+    MODE_BYTE_AUTO = 0x08,
+  };
+
+  enum FAN_BYTE : uint8_t {
+    FAN_AUTO = 0x00,
+    FAN_QUIET = 0x01,
+    FAN_1 = 0x02,
+    FAN_2 = 0x03,
+    FAN_3 = 0x05,
+    FAN_4 = 0x06,
+  };
+
+  enum VANE_BYTE : uint8_t {
+    VANE_AUTO = 0x00,
+    VANE_1 = 0x01,
+    VANE_2 = 0x02,
+    VANE_3 = 0x03,
+    VANE_4 = 0x04,
+    VANE_5 = 0x05,
+    VANE_SWING = 0x07,
+  };
+
+  enum HORIZONTAL_VANE_BYTE : uint8_t {
+    HV_AUTO = 0x00,
+    HV_LEFT_FULL = 0x01,
+    HV_LEFT = 0x02,
+    HV_CENTER = 0x03,
+    HV_RIGHT = 0x04,
+    HV_RIGHT_FULL = 0x05,
+    HV_SPLIT = 0x08,
+    HV_SWING = 0x0c,
+  };
+
+  SettingsSetRequestPacket() : Packet(RawPacket(PacketType::set_request, 16)) {
+    pkt_.setPayloadByte(0, static_cast<uint8_t>(SetCommand::settings));
+  }
+  using Packet::Packet;
+
+  SettingsSetRequestPacket &setPower(bool isOn);
+  SettingsSetRequestPacket &setMode(MODE_BYTE mode);
+  SettingsSetRequestPacket &setTargetTemperature(float temperatureDegressC);
+  SettingsSetRequestPacket &setFan(FAN_BYTE fan);
+  SettingsSetRequestPacket &setVane(VANE_BYTE vane);
+  SettingsSetRequestPacket &setHorizontalVane(HORIZONTAL_VANE_BYTE horizontal_vane);
+
+ private:
+  void addSettingsFlag(SETTING_FLAG flagToAdd);
+  void addSettingsFlag2(SETTING_FLAG2 flag2ToAdd);
+};
+
+class RemoteTemperatureSetRequestPacket : public Packet {
+  static const uint8_t PLINDEX_LEGACY_REMOTE_TEMPERATURE = 2;
+  static const uint8_t PLINDEX_REMOTE_TEMPERATURE = 3;
+
+ public:
+  RemoteTemperatureSetRequestPacket() : Packet(RawPacket(PacketType::set_request, 4)) {
+    pkt_.setPayloadByte(0, static_cast<uint8_t>(SetCommand::remote_temperature));
+  }
+  using Packet::Packet;
+
+  float getRemoteTemperature() const;
+
+  RemoteTemperatureSetRequestPacket &setRemoteTemperature(float temperatureDegressC);
+  RemoteTemperatureSetRequestPacket &useInternalTemperature();
+
+  std::string to_string() const override;
+};
+
+class SetResponsePacket : public Packet {
+  using Packet::Packet;
+
+ public:
+  SetResponsePacket() : Packet(RawPacket(PacketType::set_response, 16)) {}
+
+  uint8_t getResultCode() const { return pkt_.getPayloadByte(0); }
+  bool isSuccessful() const { return getResultCode() == 0; }
+};
+
+// Sent by MHK2 but with no response; defined to allow setResponseExpected(false)
+class ThermostatHelloRequestPacket : public Packet {
+  using Packet::Packet;
+
+ public:
+  ThermostatHelloRequestPacket() : Packet(RawPacket(PacketType::set_request, 4)) {
+    pkt_.setPayloadByte(0, static_cast<uint8_t>(SetCommand::thermostat_hello));
+  }
+
+  std::string getThermostatModel() const;
+  std::string getThermostatSerial() const;
+  std::string getThermostatVersionString() const;
+
+  std::string to_string() const override;
+};
+
+// Sent by MHK2 but with no response; defined to allow setResponseExpected(false)
+class A9GetRequestPacket : public Packet {
+  using Packet::Packet;
+
+ public:
+  A9GetRequestPacket() : Packet(RawPacket(PacketType::get_request, 10)) {
+    pkt_.setPayloadByte(0, static_cast<uint8_t>(GetCommand::a_9));
+  }
+};
+
+class PacketProcessor {
+ public:
+  virtual void processPacket(const Packet &packet){};
+  virtual void processPacket(const ConnectRequestPacket &packet){};
+  virtual void processPacket(const ConnectResponsePacket &packet){};
+  virtual void processPacket(const ExtendedConnectRequestPacket &packet){};
+  virtual void processPacket(const ExtendedConnectResponsePacket &packet){};
+  virtual void processPacket(const GetRequestPacket &packet){};
+  virtual void processPacket(const SettingsGetResponsePacket &packet){};
+  virtual void processPacket(const CurrentTempGetResponsePacket &packet){};
+  virtual void processPacket(const StatusGetResponsePacket &packet){};
+  virtual void processPacket(const StandbyGetResponsePacket &packet){};
+  virtual void processPacket(const ErrorStateGetResponsePacket &packet){};
+  virtual void processPacket(const RemoteTemperatureSetRequestPacket &packet){};
+  virtual void processPacket(const SetResponsePacket &packet){};
+};
+
+}  // namespace mitsubishi_uart
+}  // namespace esphome

--- a/esphome/components/mitsubishi_uart/muart_rawpacket.cpp
+++ b/esphome/components/mitsubishi_uart/muart_rawpacket.cpp
@@ -1,0 +1,64 @@
+#include "muart_rawpacket.h"
+
+namespace esphome {
+namespace mitsubishi_uart {
+
+// Creates an empty packet
+RawPacket::RawPacket(PacketType packet_type, uint8_t payload_size, SourceBridge source_bridge,
+                     ControllerAssociation controller_association)
+    : length{(uint8_t) (payload_size + PACKET_HEADER_SIZE + 1)},
+      checksumIndex{(uint8_t) (length - 1)},
+      sourceBridge{source_bridge},
+      controllerAssociation{controller_association} {
+  memcpy(packetBytes, EMPTY_PACKET, length);
+  packetBytes[PACKET_HEADER_INDEX_PACKET_TYPE] = static_cast<uint8_t>(packet_type);
+  packetBytes[PACKET_HEADER_INDEX_PAYLOAD_LENGTH] = payload_size;
+
+  updateChecksum();
+}
+
+// Creates a packet with the provided bytes
+RawPacket::RawPacket(const uint8_t packet_bytes[], const uint8_t packet_length, SourceBridge source_bridge,
+                     ControllerAssociation controller_association)
+    : length{(uint8_t) packet_length},
+      checksumIndex{(uint8_t) (packet_length - 1)},
+      sourceBridge{source_bridge},
+      controllerAssociation{controller_association} {
+  memcpy(packetBytes, packet_bytes, packet_length);
+
+  if (!this->isChecksumValid()) {
+    // For now, just log this as information (we can decide if we want to process it elsewhere)
+    ESP_LOGI(PTAG, "Packet of type %x has invalid checksum!", this->getPacketType());
+  }
+}
+
+// Creates an empty RawPacket
+RawPacket::RawPacket() {
+  // TODO: Is this okay?
+}
+
+uint8_t RawPacket::calculateChecksum() const {
+  uint8_t sum = 0;
+  for (int i = 0; i < checksumIndex; i++) {
+    sum += packetBytes[i];
+  }
+
+  return (0xfc - sum) & 0xff;
+}
+
+RawPacket &RawPacket::updateChecksum() {
+  packetBytes[checksumIndex] = calculateChecksum();
+  return *this;
+}
+
+bool RawPacket::isChecksumValid() const { return packetBytes[checksumIndex] == calculateChecksum(); }
+
+// Sets a payload byte and automatically updates the packet checksum
+RawPacket &RawPacket::setPayloadByte(const uint8_t payload_byte_index, const uint8_t value) {
+  packetBytes[PACKET_HEADER_SIZE + payload_byte_index] = value;
+  updateChecksum();
+  return *this;
+}
+
+}  // namespace mitsubishi_uart
+}  // namespace esphome

--- a/esphome/components/mitsubishi_uart/muart_rawpacket.h
+++ b/esphome/components/mitsubishi_uart/muart_rawpacket.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/climate/climate.h"
+#include "esphome/components/uart/uart.h"
+#include <type_traits>
+
+namespace esphome {
+namespace mitsubishi_uart {
+
+static const char *PTAG = "mitsubishi_uart.packets";
+
+const uint8_t BYTE_CONTROL = 0xfc;
+const uint8_t PACKET_MAX_SIZE = 22;  // Used to intialize empty packet
+const uint8_t PACKET_HEADER_SIZE = 5;
+const uint8_t PACKET_HEADER_INDEX_PACKET_TYPE = 1;
+const uint8_t PACKET_HEADER_INDEX_PAYLOAD_LENGTH = 4;
+
+// TODO: Figure out something here so we don't have to static_cast<uint8_t> as much
+enum class PacketType : uint8_t {
+  connect_request = 0x5a,
+  connect_response = 0x7a,
+  get_request = 0x42,
+  get_response = 0x62,
+  set_request = 0x41,
+  set_response = 0x61,
+  extended_connect_request = 0x5b,
+  extended_connect_response = 0x7b
+};
+
+// Used to specify certain packet subtypes
+enum class GetCommand : uint8_t {
+  settings = 0x02,
+  current_temp = 0x03,
+  error_info = 0x04,
+  status = 0x06,
+  standby = 0x09,
+  a_9 = 0xa9
+};
+
+// Used to specify certain packet subtypes
+enum class SetCommand : uint8_t { settings = 0x01, remote_temperature = 0x07, thermostat_hello = 0xa7 };
+
+// Which MUARTBridge was the packet read from (used to determine flow direction of the packet)
+enum class SourceBridge { none, heatpump, thermostat };
+
+// Specifies which controller the packet "belongs" to (i.e. which controler created it either directly or via a request
+// packet)
+enum class ControllerAssociation { muart, thermostat };
+
+static const uint8_t EMPTY_PACKET[PACKET_MAX_SIZE] = {BYTE_CONTROL,        // Sync
+                                                      0x00,                // Packet type
+                                                      0x01,         0x30,  // Unknown
+                                                      0x00,                // Payload Size
+                                                      0x00,         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                                      0x00,         0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // Payload
+                                                      0x00};
+
+/* A class representing the raw packet sent to or from the Mitsubishi equipment with definitions
+for header indexes, checksum calculations, utility methods, etc.  These generally shouldn't be accessed
+directly outside the MUARTBridge, and the Packet class (or its subclasses) should be used instead.
+*/
+class RawPacket {
+ public:
+  RawPacket(
+      const uint8_t packet_bytes[], const uint8_t packet_length, SourceBridge source_bridge = SourceBridge::none,
+      ControllerAssociation controller_association = ControllerAssociation::muart);  // For reading or copying packets
+  // TODO: Can I hide this constructor except from optional?
+  RawPacket();  // For optional<RawPacket> construction
+  RawPacket(PacketType packet_type, uint8_t payload_size, SourceBridge source_bridge = SourceBridge::none,
+            ControllerAssociation controller_association = ControllerAssociation::muart);  // For building packets
+  virtual ~RawPacket() {}
+
+  virtual std::string to_string() const { return format_hex_pretty(&getBytes()[0], getLength()); };
+
+  uint8_t getLength() const { return length; };
+  const uint8_t *getBytes() const { return packetBytes; };  // Primarily for sending packets
+
+  bool isChecksumValid() const;
+
+  // Returns the packet type byte
+  uint8_t getPacketType() const { return packetBytes[PACKET_HEADER_INDEX_PACKET_TYPE]; };
+  // Returns the first byte of the payload, often used as a command
+  uint8_t getCommand() const { return getPayloadByte(PLINDEX_COMMAND); };
+
+  SourceBridge getSourceBridge() const { return sourceBridge; };
+  ControllerAssociation getControllerAssociation() const { return controllerAssociation; };
+
+  RawPacket &setPayloadByte(const uint8_t payload_byte_index, const uint8_t value);
+  uint8_t getPayloadByte(const uint8_t payload_byte_index) const {
+    return packetBytes[PACKET_HEADER_SIZE + payload_byte_index];
+  };
+
+ private:
+  static const int PLINDEX_COMMAND = 0;
+
+  uint8_t packetBytes[PACKET_MAX_SIZE]{};
+  uint8_t length;
+  uint8_t checksumIndex;
+
+  SourceBridge sourceBridge;
+  ControllerAssociation controllerAssociation;
+
+  uint8_t calculateChecksum() const;
+  RawPacket &updateChecksum();
+};
+
+}  // namespace mitsubishi_uart
+}  // namespace esphome

--- a/esphome/components/mitsubishi_uart/muart_select.h
+++ b/esphome/components/mitsubishi_uart/muart_select.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "esphome/components/select/select.h"
+#include "mitsubishi_uart.h"
+
+namespace esphome {
+namespace mitsubishi_uart {
+
+class MUARTSelect : public select::Select, public Parented<MitsubishiUART> {
+ public:
+  MUARTSelect() = default;
+  using Parented<MitsubishiUART>::Parented;
+
+ protected:
+  void control(const std::string &value) override = 0;
+};
+
+class TemperatureSourceSelect : public MUARTSelect {
+ protected:
+  void control(const std::string &value) {
+    if (parent_->select_temperature_source(value)) {
+      publish_state(value);
+    }
+  }
+};
+
+class VanePositionSelect : public MUARTSelect {
+ protected:
+  void control(const std::string &value) {
+    if (parent_->select_vane_position(value)) {
+      publish_state(value);
+    }
+  }
+};
+
+class HorizontalVanePositionSelect : public MUARTSelect {
+ protected:
+  void control(const std::string &value) {
+    if (parent_->select_horizontal_vane_position(value)) {
+      publish_state(value);
+    }
+  }
+};
+
+}  // namespace mitsubishi_uart
+}  // namespace esphome

--- a/esphome/components/mitsubishi_uart/muart_switch.h
+++ b/esphome/components/mitsubishi_uart/muart_switch.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "esphome/components/switch/switch.h"
+#include "mitsubishi_uart.h"
+
+namespace esphome {
+namespace mitsubishi_uart {
+
+class MUARTSwitch : public switch_::Switch, public Component, public Parented<MitsubishiUART> {
+ public:
+  MUARTSwitch() = default;
+  using Parented<MitsubishiUART>::Parented;
+  void setup() override {
+    this->state = this->get_initial_state_with_restore_mode().value_or(false);
+    this->parent_->set_active_mode(state);
+  };
+
+ protected:
+  virtual void write_state(bool state) override;
+};
+
+class ActiveModeSwitch : public MUARTSwitch {
+ protected:
+  void write_state(bool new_state) {
+    this->publish_state(new_state);
+    this->parent_->set_active_mode(new_state);
+  }
+};
+
+}  // namespace mitsubishi_uart
+}  // namespace esphome

--- a/esphome/components/mitsubishi_uart/muart_utils.h
+++ b/esphome/components/mitsubishi_uart/muart_utils.h
@@ -1,0 +1,77 @@
+#pragma once
+
+namespace esphome {
+namespace mitsubishi_uart {
+
+class MUARTUtils {
+ public:
+  /// Read a string out of data, wordSize bits at a time.
+  /// Used to decode serial numbers and other information from a thermostat.
+  static std::string DecodeNBitString(const uint8_t data[], size_t dataLength, size_t wordSize) {
+    auto resultLength = (dataLength / wordSize) + (dataLength % wordSize != 0);
+    auto result = std::string();
+
+    for (int i = 0; i < resultLength; i++) {
+      auto bits = BitSlice(data, i * wordSize, ((i + 1) * wordSize) - 1);
+      if (bits <= 0x1F)
+        bits += 0x40;
+      result += (char) bits;
+    }
+
+    return result;
+  }
+
+  static float TempScaleAToDegC(const uint8_t value) { return (float) (value - 128) / 2.0f; }
+
+  static uint8_t DegCToTempScaleA(const float value) {
+    // Special cases
+    if (value < -64)
+      return 0;
+    if (value > 63.5f)
+      return 0xFF;
+
+    return (uint8_t) round(value * 2) + 128;
+  }
+
+  static float LegacyTargetTempToDegC(const uint8_t value) {
+    return ((float) (31 - (value & 0x0F)) + (((value & 0xF0) > 0) ? 0.5f : 0));
+  }
+
+  static uint8_t DegCToLegacyTargetTemp(const float value) {
+    // Special cases per docs
+    if (value < 16)
+      return 0x0F;
+    if (value > 31.5)
+      return 0x10;
+
+    return ((31 - (uint8_t) value) & 0xF) + (((int) (value * 2) % 2) << 4);
+  }
+
+  static float LegacyRoomTempToDegC(const uint8_t value) { return (float) value + 10; }
+
+  static uint8_t DegCToLegacyRoomTemp(const float value) {
+    if (value < 10)
+      return 0x00;
+    if (value > 41)
+      return 0x1F;
+
+    return (uint8_t) value - 10;
+  }
+
+ private:
+  /// Extract the specified bits (inclusive) from an arbitrarily-sized byte array. Does not perform bounds checks.
+  static uint64_t BitSlice(const uint8_t ds[], size_t start, size_t end) {
+    // Lazies! https://stackoverflow.com/a/25297870/1817097
+    uint64_t s = 0;
+    size_t i, n = (end - 1) / 8;
+    for (i = 0; i <= n; ++i)
+      s = (s << 8) + ds[i];
+    s >>= (n + 1) * 8 - end;
+    uint64_t mask = (((uint64_t) 1) << (end - start + 1)) - 1;  // len = end - start + 1
+    s &= mask;
+    return s;
+  }
+};
+
+}  // namespace mitsubishi_uart
+}  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

Pulling mitsubishi_uart component from [previous repo](https://github.com/Sammy1Am/mitsubishi-uart) into this one.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
