### PR TITLE
Kumo Emulation Mode

### DIFF
--- a/esphome/components/mitsubishi_itp/climate.py
+++ b/esphome/components/mitsubishi_itp/climate.py
@@ -42,7 +42,6 @@ AUTO_LOAD = [
 ]
 DEPENDENCIES = [
     "uart",
-    "time",
     "climate",
     "sensor",
     "binary_sensor",

--- a/esphome/components/mitsubishi_itp/climate.py
+++ b/esphome/components/mitsubishi_itp/climate.py
@@ -339,8 +339,8 @@ async def to_code(config):
     if CONF_TIME_SOURCE in config:
         rtc_component = await cg.get_variable(config[CONF_TIME_SOURCE])
         cg.add(getattr(muart_component, "set_time_source")(rtc_component))
-    elif CONF_UART_THERMOSTAT in config:
-        raise cv.RequiredFieldInvalid(f"{CONF_TIME_SOURCE} is required if {CONF_TS_UART} is set.")
+    elif CONF_UART_THERMOSTAT in config and not config.get(CONF_ENABLE_KUMO_EMULATION):
+        raise cv.RequiredFieldInvalid(f"{CONF_TIME_SOURCE} is required if {CONF_ENABLE_KUMO_EMULATION} is set.")
 
     # Traits
     traits = muart_component.config_traits()

--- a/esphome/components/mitsubishi_itp/climate.py
+++ b/esphome/components/mitsubishi_itp/climate.py
@@ -39,15 +39,11 @@ AUTO_LOAD = [
     "binary_sensor",
     "button",
     "text_sensor",
+    "time",
 ]
 DEPENDENCIES = [
     "uart",
     "climate",
-    "sensor",
-    "binary_sensor",
-    "button",
-    "text_sensor",
-    "select",
 ]
 
 CONF_UART_HEATPUMP = "uart_heatpump"

--- a/esphome/components/mitsubishi_itp/climate.py
+++ b/esphome/components/mitsubishi_itp/climate.py
@@ -74,7 +74,9 @@ CONF_TEMPERATURE_SOURCES = (
 )
 
 CONF_DISABLE_ACTIVE_MODE = "disable_active_mode"
-CONF_ENHANCED_MHK_SUPPORT = "enhanced_mhk"  # EXPERIMENTAL. Will be set to default eventually.
+CONF_ENHANCED_MHK_SUPPORT = (
+    "enhanced_mhk"  # EXPERIMENTAL. Will be set to default eventually.
+)
 
 DEFAULT_POLLING_INTERVAL = "5s"
 
@@ -172,14 +174,14 @@ SENSORS = dict[str, tuple[str, cv.Schema, callable]](
                 state_class=STATE_CLASS_MEASUREMENT,
                 accuracy_decimals=0,
             ),
-            sensor.register_sensor
+            sensor.register_sensor,
         ),
         CONF_THERMOSTAT_BATTERY: (
             "Thermostat Battery",
             text_sensor.text_sensor_schema(
                 icon="mdi:battery",
             ),
-            text_sensor.register_text_sensor
+            text_sensor.register_text_sensor,
         ),
         "compressor_frequency": (
             "Compressor Frequency",
@@ -340,7 +342,9 @@ async def to_code(config):
         rtc_component = await cg.get_variable(config[CONF_TIME_SOURCE])
         cg.add(getattr(muart_component, "set_time_source")(rtc_component))
     elif CONF_UART_THERMOSTAT in config and config.get(CONF_ENHANCED_MHK_SUPPORT):
-        raise cv.RequiredFieldInvalid(f"{CONF_TIME_SOURCE} is required if {CONF_ENHANCED_MHK_SUPPORT} is set.")
+        raise cv.RequiredFieldInvalid(
+            f"{CONF_TIME_SOURCE} is required if {CONF_ENHANCED_MHK_SUPPORT} is set."
+        )
 
     # Traits
     traits = muart_component.config_traits()
@@ -362,8 +366,14 @@ async def to_code(config):
         registration_function,
     ) in SENSORS.items():
         # Only add the thermostat temp if we have a TS_UART
-        if ((CONF_UART_THERMOSTAT not in config) and
-                (sensor_designator in [CONF_THERMOSTAT_TEMPERATURE, CONF_THERMOSTAT_HUMIDITY, CONF_THERMOSTAT_BATTERY])):
+        if (CONF_UART_THERMOSTAT not in config) and (
+            sensor_designator
+            in [
+                CONF_THERMOSTAT_TEMPERATURE,
+                CONF_THERMOSTAT_HUMIDITY,
+                CONF_THERMOSTAT_BATTERY,
+            ]
+        ):
             continue
 
         sensor_conf = config[CONF_SENSORS][sensor_designator]
@@ -424,4 +434,6 @@ async def to_code(config):
         cg.add(getattr(muart_component, "set_active_mode")(not dam_conf))
 
     if enhanced_mhk_protocol := config.get(CONF_ENHANCED_MHK_SUPPORT):
-        cg.add(getattr(muart_component, "set_enhanced_mhk_support")(enhanced_mhk_protocol))
+        cg.add(
+            getattr(muart_component, "set_enhanced_mhk_support")(enhanced_mhk_protocol)
+        )

--- a/esphome/components/mitsubishi_itp/climate.py
+++ b/esphome/components/mitsubishi_itp/climate.py
@@ -74,6 +74,7 @@ CONF_TEMPERATURE_SOURCES = (
 )
 
 CONF_DISABLE_ACTIVE_MODE = "disable_active_mode"
+CONF_ENABLE_KUMO_EMULATION = "kumo_emulation"  # EXPERIMENTAL FEATURE - Enables Kumo packet handling.
 
 DEFAULT_POLLING_INTERVAL = "5s"
 
@@ -135,6 +136,7 @@ BASE_SCHEMA = climate.CLIMATE_SCHEMA.extend(
             cv.use_id(sensor.Sensor)
         ),
         cv.Optional(CONF_DISABLE_ACTIVE_MODE, default=False): cv.boolean,
+        cv.Optional(CONF_ENABLE_KUMO_EMULATION, default=False): cv.boolean,
     }
 ).extend(cv.polling_component_schema(DEFAULT_POLLING_INTERVAL))
 
@@ -420,3 +422,6 @@ async def to_code(config):
     # Debug Settings
     if dam_conf := config.get(CONF_DISABLE_ACTIVE_MODE):
         cg.add(getattr(muart_component, "set_active_mode")(not dam_conf))
+
+    if kumo_emulation := config.get(CONF_ENABLE_KUMO_EMULATION):
+        cg.add(getattr(muart_component, "set_kumo_emulation_mode")(kumo_emulation))

--- a/esphome/components/mitsubishi_itp/climate.py
+++ b/esphome/components/mitsubishi_itp/climate.py
@@ -74,7 +74,7 @@ CONF_TEMPERATURE_SOURCES = (
 )
 
 CONF_DISABLE_ACTIVE_MODE = "disable_active_mode"
-CONF_ENABLE_KUMO_EMULATION = "kumo_emulation"  # EXPERIMENTAL FEATURE - Enables Kumo packet handling.
+CONF_ENHANCED_MHK_SUPPORT = "enhanced_mhk"  # EXPERIMENTAL. Will be set to default eventually.
 
 DEFAULT_POLLING_INTERVAL = "5s"
 
@@ -136,7 +136,7 @@ BASE_SCHEMA = climate.CLIMATE_SCHEMA.extend(
             cv.use_id(sensor.Sensor)
         ),
         cv.Optional(CONF_DISABLE_ACTIVE_MODE, default=False): cv.boolean,
-        cv.Optional(CONF_ENABLE_KUMO_EMULATION, default=False): cv.boolean,
+        cv.Optional(CONF_ENHANCED_MHK_SUPPORT, default=False): cv.boolean,
     }
 ).extend(cv.polling_component_schema(DEFAULT_POLLING_INTERVAL))
 
@@ -339,8 +339,8 @@ async def to_code(config):
     if CONF_TIME_SOURCE in config:
         rtc_component = await cg.get_variable(config[CONF_TIME_SOURCE])
         cg.add(getattr(muart_component, "set_time_source")(rtc_component))
-    elif CONF_UART_THERMOSTAT in config and not config.get(CONF_ENABLE_KUMO_EMULATION):
-        raise cv.RequiredFieldInvalid(f"{CONF_TIME_SOURCE} is required if {CONF_ENABLE_KUMO_EMULATION} is set.")
+    elif CONF_UART_THERMOSTAT in config and config.get(CONF_ENHANCED_MHK_SUPPORT):
+        raise cv.RequiredFieldInvalid(f"{CONF_TIME_SOURCE} is required if {CONF_ENHANCED_MHK_SUPPORT} is set.")
 
     # Traits
     traits = muart_component.config_traits()
@@ -423,5 +423,5 @@ async def to_code(config):
     if dam_conf := config.get(CONF_DISABLE_ACTIVE_MODE):
         cg.add(getattr(muart_component, "set_active_mode")(not dam_conf))
 
-    if kumo_emulation := config.get(CONF_ENABLE_KUMO_EMULATION):
-        cg.add(getattr(muart_component, "set_kumo_emulation_mode")(kumo_emulation))
+    if enhanced_mhk_protocol := config.get(CONF_ENHANCED_MHK_SUPPORT):
+        cg.add(getattr(muart_component, "set_enhanced_mhk_support")(enhanced_mhk_protocol))

--- a/esphome/components/mitsubishi_itp/mitsubishi_uart-climatecall.cpp
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart-climatecall.cpp
@@ -83,18 +83,19 @@ void MitsubishiUART::control(const climate::ClimateCall &call) {
     switch (mode) {
       case climate::CLIMATE_MODE_COOL:
       case climate::CLIMATE_MODE_DRY:
-        this->last_cool_setpoint_ = target_temperature;
+        this->mhk_state_.cool_setpoint_ = target_temperature;
         break;
       case climate::CLIMATE_MODE_HEAT:
-        this->last_heat_setpoint_ = target_temperature;
+        this->mhk_state_.heat_setpoint_ = target_temperature;
         break;
       case climate::CLIMATE_MODE_HEAT_COOL:
         if (this->get_traits().get_supports_two_point_target_temperature()) {
-          this->last_heat_setpoint_ = target_temperature_low;
-          this->last_cool_setpoint_ = target_temperature_high;
+          this->mhk_state_.cool_setpoint_ = target_temperature_low;
+          this->mhk_state_.heat_setpoint_ = target_temperature_high;
         } else {
-          // this->last_heat_setpoint_ = target_temperature;
-          // this->last_cool_setpoint_ = target_temperature;
+          // HACK: This is not accurate, but it's good enough for testing.
+          this->mhk_state_.cool_setpoint_ = target_temperature + 2;
+          this->mhk_state_.heat_setpoint_ = target_temperature - 2;
         }
       default:
         break;

--- a/esphome/components/mitsubishi_itp/mitsubishi_uart-climatecall.cpp
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart-climatecall.cpp
@@ -111,10 +111,10 @@ void MitsubishiUART::control(const climate::ClimateCall &call) {
   // Queue the packet to be sent first (so any subsequent update packets come *after* our changes)
   hp_bridge_.send_packet(set_request_packet);
 
-  // Publish state and any sensor changes (shouldn't be any a a result of this function, but
+  // Publish state and any sensor changes (shouldn't be any a result of this function, but
   // since they lazy-publish, no harm in trying)
   do_publish_();
-};
+}
 
 }  // namespace mitsubishi_itp
 }  // namespace esphome

--- a/esphome/components/mitsubishi_itp/mitsubishi_uart-climatecall.cpp
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart-climatecall.cpp
@@ -78,6 +78,27 @@ void MitsubishiUART::control(const climate::ClimateCall &call) {
   if (call.get_target_temperature().has_value()) {
     target_temperature = call.get_target_temperature().value();
     set_request_packet.set_target_temperature(call.get_target_temperature().value());
+
+    // update our MHK tracking setpoints accordingly
+    switch (mode) {
+      case climate::CLIMATE_MODE_COOL:
+      case climate::CLIMATE_MODE_DRY:
+        this->last_cool_setpoint_ = target_temperature;
+        break;
+      case climate::CLIMATE_MODE_HEAT:
+        this->last_heat_setpoint_ = target_temperature;
+        break;
+      case climate::CLIMATE_MODE_HEAT_COOL:
+        if (this->get_traits().get_supports_two_point_target_temperature()) {
+          this->last_heat_setpoint_ = target_temperature_low;
+          this->last_cool_setpoint_ = target_temperature_high;
+        } else {
+          // this->last_heat_setpoint_ = target_temperature;
+          // this->last_cool_setpoint_ = target_temperature;
+        }
+      default:
+        break;
+    }
   }
 
   // TODO:

--- a/esphome/components/mitsubishi_itp/mitsubishi_uart-packetprocessing.cpp
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart-packetprocessing.cpp
@@ -388,9 +388,11 @@ void MitsubishiUART::process_packet(const RemoteTemperatureSetRequestPacket &pac
 
 void MitsubishiUART::process_packet(const ThermostatSensorStatusPacket &packet) {
   if (!enhanced_mhk_support_) {
+    ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
+
     route_packet_(packet);
     return;
-  };
+  }
 
   ESP_LOGV(TAG, "Processing inbound %s", packet.to_string().c_str());
 
@@ -411,20 +413,23 @@ void MitsubishiUART::process_packet(const ThermostatSensorStatusPacket &packet) 
 
 void MitsubishiUART::process_packet(const ThermostatHelloPacket &packet) {
   if (!enhanced_mhk_support_) {
+    ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
+
     route_packet_(packet);
     return;
-  };
+  }
 
   ESP_LOGV(TAG, "Processing inbound %s", packet.to_string().c_str());
-
   ts_bridge_->send_packet(SetResponsePacket());
 }
 
 void MitsubishiUART::process_packet(const ThermostatStateUploadPacket &packet) {
   if (!enhanced_mhk_support_) {
+    ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
+
     route_packet_(packet);
     return;
-  };
+  }
 
   ESP_LOGV(TAG, "Processing inbound %s", packet.to_string().c_str());
 
@@ -436,9 +441,11 @@ void MitsubishiUART::process_packet(const ThermostatStateUploadPacket &packet) {
 
 void MitsubishiUART::process_packet(const ThermostatAASetRequestPacket &packet) {
   if (!enhanced_mhk_support_) {
+    ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
+
     route_packet_(packet);
     return;
-  };
+  }
 
   ESP_LOGV(TAG, "Processing inbound ThermostatAASetRequestPacket: %s", packet.to_string().c_str());
 

--- a/esphome/components/mitsubishi_itp/mitsubishi_uart-packetprocessing.cpp
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart-packetprocessing.cpp
@@ -36,13 +36,13 @@ void MitsubishiUART::process_packet(const ConnectResponsePacket &packet) {
   ESP_LOGI(TAG, "Heatpump connected.");
 };
 
-void MitsubishiUART::process_packet(const ExtendedConnectRequestPacket &packet) {
+void MitsubishiUART::process_packet(const BaseCapabilitiesRequestPacket &packet) {
   // Nothing to be done for these except forward them along from thermostat to heat pump.
   // This method defined so that these packets are not "unhandled"
   ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
   route_packet_(packet);
 };
-void MitsubishiUART::process_packet(const ExtendedConnectResponsePacket &packet) {
+void MitsubishiUART::process_packet(const BaseCapabilitiesResponsePacket &packet) {
   ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
   route_packet_(packet);
   // Not sure if there's any needed content in this response, so assume we're connected.

--- a/esphome/components/mitsubishi_itp/mitsubishi_uart-packetprocessing.cpp
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart-packetprocessing.cpp
@@ -20,28 +20,28 @@ void MitsubishiUART::process_packet(const Packet &packet) {
   ESP_LOGI(TAG, "Generic unhandled packet type %x received.", packet.get_packet_type());
   ESP_LOGD(TAG, "%s", packet.to_string().c_str());
   route_packet_(packet);
-};
+}
 
 void MitsubishiUART::process_packet(const ConnectRequestPacket &packet) {
   // Nothing to be done for these except forward them along from thermostat to heat pump.
   // This method defined so that these packets are not "unhandled"
   ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
   route_packet_(packet);
-};
+}
 void MitsubishiUART::process_packet(const ConnectResponsePacket &packet) {
   ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
   route_packet_(packet);
   // Not sure if there's any needed content in this response, so assume we're connected.
   hp_connected_ = true;
   ESP_LOGI(TAG, "Heatpump connected.");
-};
+}
 
 void MitsubishiUART::process_packet(const CapabilitiesRequestPacket &packet) {
   // Nothing to be done for these except forward them along from thermostat to heat pump.
   // This method defined so that these packets are not "unhandled"
   ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
   route_packet_(packet);
-};
+}
 void MitsubishiUART::process_packet(const CapabilitiesResponsePacket &packet) {
   ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
   route_packet_(packet);
@@ -50,7 +50,7 @@ void MitsubishiUART::process_packet(const CapabilitiesResponsePacket &packet) {
   hp_connected_ = true;
   capabilities_cache_ = packet;
   ESP_LOGI(TAG, "Received heat pump identification packet.");
-};
+}
 
 void MitsubishiUART::process_packet(const GetRequestPacket &packet) {
   ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
@@ -217,7 +217,7 @@ void MitsubishiUART::process_packet(const SettingsGetResponsePacket &packet) {
       ESP_LOGW(TAG, "Vane in unknown horizontal position %x", packet.get_horizontal_vane());
   }
   publish_on_update_ |= (old_horizontal_vane_position != horizontal_vane_position_select_->state);
-};
+}
 
 void MitsubishiUART::process_packet(const CurrentTempGetResponsePacket &packet) {
   ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
@@ -233,7 +233,7 @@ void MitsubishiUART::process_packet(const CurrentTempGetResponsePacket &packet) 
     outdoor_temperature_sensor_->raw_state = packet.get_outdoor_temp();
     publish_on_update_ |= (old_outdoor_temperature != outdoor_temperature_sensor_->raw_state);
   }
-};
+}
 
 void MitsubishiUART::process_packet(const StatusGetResponsePacket &packet) {
   ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
@@ -292,7 +292,7 @@ void MitsubishiUART::process_packet(const StatusGetResponsePacket &packet) {
 
     publish_on_update_ |= (old_compressor_frequency != compressor_frequency_sensor_->raw_state);
   }
-};
+}
 void MitsubishiUART::process_packet(const RunStateGetResponsePacket &packet) {
   ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
   route_packet_(packet);
@@ -433,8 +433,10 @@ void MitsubishiUART::process_packet(const ThermostatStateUploadPacket &packet) {
 
   ESP_LOGV(TAG, "Processing inbound %s", packet.to_string().c_str());
 
-  if (packet.get_flags() & 0x08) this->mhk_state_.heat_setpoint_ = packet.get_heat_setpoint();
-  if (packet.get_flags() & 0x10) this->mhk_state_.cool_setpoint_ = packet.get_cool_setpoint();
+  if (packet.get_flags() & 0x08)
+    this->mhk_state_.heat_setpoint_ = packet.get_heat_setpoint();
+  if (packet.get_flags() & 0x10)
+    this->mhk_state_.cool_setpoint_ = packet.get_cool_setpoint();
 
   ts_bridge_->send_packet(SetResponsePacket());
 }
@@ -463,7 +465,7 @@ void MitsubishiUART::handle_thermostat_state_download_request(const GetRequestPa
   if (!enhanced_mhk_support_) {
     route_packet_(packet);
     return;
-  };
+  }
 
   auto response = ThermostatStateDownloadResponsePacket();
 
@@ -475,7 +477,7 @@ void MitsubishiUART::handle_thermostat_state_download_request(const GetRequestPa
     response.set_timestamp(this->time_source_->now());
   } else {
     ESP_LOGW(TAG, "No time source specified. Cannot provide accurate time!");
-    response.set_timestamp(ESPTime::from_epoch_utc(1704067200)); // 2024-01-01 00:00:00Z
+    response.set_timestamp(ESPTime::from_epoch_utc(1704067200));  // 2024-01-01 00:00:00Z
   }
 
   ts_bridge_->send_packet(response);
@@ -485,7 +487,7 @@ void MitsubishiUART::handle_thermostat_ab_get_request(const GetRequestPacket &pa
   if (!enhanced_mhk_support_) {
     route_packet_(packet);
     return;
-  };
+  }
 
   auto response = ThermostatABGetResponsePacket();
 

--- a/esphome/components/mitsubishi_itp/mitsubishi_uart-packetprocessing.cpp
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart-packetprocessing.cpp
@@ -384,6 +384,8 @@ void MitsubishiUART::process_packet(const RemoteTemperatureSetRequestPacket &pac
 }
 
 void MitsubishiUART::process_packet(const KumoThermostatSensorStatusPacket &packet) {
+  if (!kumo_emulation_mode_) return;
+
   ESP_LOGV(TAG, "Processing inbound %s", packet.to_string().c_str());
 
   if (thermostat_humidity_sensor_ && packet.get_flags() & 0x04) {
@@ -402,12 +404,16 @@ void MitsubishiUART::process_packet(const KumoThermostatSensorStatusPacket &pack
 }
 
 void MitsubishiUART::process_packet(const KumoThermostatHelloPacket &packet) {
+  if (!kumo_emulation_mode_) return;
+
   ESP_LOGV(TAG, "Processing inbound %s", packet.to_string().c_str());
 
   ts_bridge_->send_packet(SetResponsePacket());
 }
 
 void MitsubishiUART::process_packet(const KumoThermostatStateSyncPacket &packet) {
+  if (!kumo_emulation_mode_) return;
+
   ESP_LOGV(TAG, "Processing inbound %s", packet.to_string().c_str());
 
   if (packet.get_flags() & 0x08) this->last_heat_setpoint_ = packet.get_heat_setpoint();
@@ -417,6 +423,8 @@ void MitsubishiUART::process_packet(const KumoThermostatStateSyncPacket &packet)
 }
 
 void MitsubishiUART::process_packet(const KumoAASetRequestPacket &packet) {
+  if (!kumo_emulation_mode_) return;
+
   ESP_LOGV(TAG, "Processing inbound KumoAASetRequestPacket: %s", packet.to_string().c_str());
 
   ts_bridge_->send_packet(SetResponsePacket());
@@ -430,6 +438,8 @@ void MitsubishiUART::process_packet(const SetResponsePacket &packet) {
 
 // Process incoming data requests (Kumo)
 void MitsubishiUART::handle_kumo_adapter_state_get_request(const GetRequestPacket &packet) {
+  if (!kumo_emulation_mode_) return;
+
   auto response = KumoCloudStateSyncPacket();
 
   response.set_heat_setpoint(this->last_heat_setpoint_);
@@ -446,6 +456,8 @@ void MitsubishiUART::handle_kumo_adapter_state_get_request(const GetRequestPacke
 }
 
 void MitsubishiUART::handle_kumo_aa_get_request(const GetRequestPacket &packet) {
+  if (!kumo_emulation_mode_) return;
+
   auto response = KumoABGetRequestPacket();
 
   ts_bridge_->send_packet(response);

--- a/esphome/components/mitsubishi_itp/mitsubishi_uart-packetprocessing.cpp
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart-packetprocessing.cpp
@@ -25,7 +25,7 @@ void MitsubishiUART::process_packet(const Packet &packet) {
 void MitsubishiUART::process_packet(const ConnectRequestPacket &packet) {
   // Nothing to be done for these except forward them along from thermostat to heat pump.
   // This method defined so that these packets are not "unhandled"
-  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+  ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
   route_packet_(packet);
 };
 void MitsubishiUART::process_packet(const ConnectResponsePacket &packet) {
@@ -39,7 +39,7 @@ void MitsubishiUART::process_packet(const ConnectResponsePacket &packet) {
 void MitsubishiUART::process_packet(const CapabilitiesRequestPacket &packet) {
   // Nothing to be done for these except forward them along from thermostat to heat pump.
   // This method defined so that these packets are not "unhandled"
-  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+  ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
   route_packet_(packet);
 };
 void MitsubishiUART::process_packet(const CapabilitiesResponsePacket &packet) {
@@ -356,7 +356,7 @@ void MitsubishiUART::process_packet(const ErrorStateGetResponsePacket &packet) {
 }
 
 void MitsubishiUART::process_packet(const SettingsSetRequestPacket &packet) {
-  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+  ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
 
   // forward this packet as-is; we're just intercepting to log.
   route_packet_(packet);
@@ -447,7 +447,7 @@ void MitsubishiUART::process_packet(const ThermostatAASetRequestPacket &packet) 
     return;
   }
 
-  ESP_LOGV(TAG, "Processing inbound ThermostatAASetRequestPacket: %s", packet.to_string().c_str());
+  ESP_LOGV(TAG, "Processing inbound %s", packet.to_string().c_str());
 
   ts_bridge_->send_packet(SetResponsePacket());
 }

--- a/esphome/components/mitsubishi_itp/mitsubishi_uart-packetprocessing.cpp
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart-packetprocessing.cpp
@@ -460,6 +460,7 @@ void MitsubishiUART::handle_thermostat_state_download_request(const GetRequestPa
 
   auto response = ThermostatStateDownloadResponsePacket();
 
+  response.set_auto_mode((mode == climate::CLIMATE_MODE_HEAT_COOL || mode == climate::CLIMATE_MODE_AUTO));
   response.set_heat_setpoint(this->mhk_state_.heat_setpoint_);
   response.set_cool_setpoint(this->mhk_state_.cool_setpoint_);
 

--- a/esphome/components/mitsubishi_itp/mitsubishi_uart.cpp
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart.cpp
@@ -207,8 +207,7 @@ void MitsubishiUART::do_publish_() {
     ESP_LOGI(TAG, "Outdoor temp differs, do publish");
     outdoor_temperature_sensor_->publish_state(outdoor_temperature_sensor_->raw_state);
   }
-  if (thermostat_humidity_sensor_ &&
-      (thermostat_humidity_sensor_->raw_state != thermostat_humidity_sensor_->state)) {
+  if (thermostat_humidity_sensor_ && (thermostat_humidity_sensor_->raw_state != thermostat_humidity_sensor_->state)) {
     ESP_LOGI(TAG, "Thermostat humidity differs, do publish");
     thermostat_humidity_sensor_->publish_state(thermostat_humidity_sensor_->raw_state);
   }

--- a/esphome/components/mitsubishi_itp/mitsubishi_uart.cpp
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart.cpp
@@ -150,7 +150,7 @@ void MitsubishiUART::update() {
   // autoconf.
   //       For now, just requesting it as part of our "init loops" is a good first step.
   if (!this->capabilities_requested_) {
-    IFACTIVE(hp_bridge_.send_packet(ExtendedConnectRequestPacket::instance()); this->capabilities_requested_ = true;)
+    IFACTIVE(hp_bridge_.send_packet(BaseCapabilitiesRequestPacket::instance()); this->capabilities_requested_ = true;)
   }
 
   // Before requesting additional updates, publish any changes waiting from packets received

--- a/esphome/components/mitsubishi_itp/mitsubishi_uart.cpp
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart.cpp
@@ -203,6 +203,11 @@ void MitsubishiUART::do_publish_() {
     ESP_LOGI(TAG, "Outdoor temp differs, do publish");
     outdoor_temperature_sensor_->publish_state(outdoor_temperature_sensor_->raw_state);
   }
+  if (thermostat_humidity_sensor_ &&
+      (thermostat_humidity_sensor_->raw_state != thermostat_humidity_sensor_->state)) {
+    ESP_LOGI(TAG, "Thermostat humidity differs, do publish");
+    thermostat_humidity_sensor_->publish_state(thermostat_humidity_sensor_->raw_state);
+  }
   if (compressor_frequency_sensor_ &&
       (compressor_frequency_sensor_->raw_state != compressor_frequency_sensor_->state)) {
     ESP_LOGI(TAG, "Compressor frequency differs, do publish");
@@ -215,6 +220,10 @@ void MitsubishiUART::do_publish_() {
   if (error_code_sensor_ && (error_code_sensor_->raw_state != error_code_sensor_->state)) {
     ESP_LOGI(TAG, "Error code state differs, do publish");
     error_code_sensor_->publish_state(error_code_sensor_->raw_state);
+  }
+  if (thermostat_battery_sensor_ && (thermostat_battery_sensor_->raw_state != thermostat_battery_sensor_->state)) {
+    ESP_LOGI(TAG, "Thermostat battery state differs, do publish");
+    thermostat_battery_sensor_->publish_state(thermostat_battery_sensor_->raw_state);
   }
 
   // Binary sensors automatically dedup publishes (I think) and so will only actually publish on change

--- a/esphome/components/mitsubishi_itp/mitsubishi_uart.cpp
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart.cpp
@@ -114,6 +114,10 @@ void MitsubishiUART::dump_config() {
   if (capabilities_cache_.has_value()) {
     ESP_LOGCONFIG(TAG, "Discovered Capabilities: %s", capabilities_cache_.value().to_string().c_str());
   }
+
+  if (kumo_emulation_mode_) {
+    ESP_LOGCONFIG(TAG, "Kumo Emulation Mode is ENABLED! This is an *experimental mode* and things may break.");
+  }
 }
 
 // Set thermostat UART component

--- a/esphome/components/mitsubishi_itp/mitsubishi_uart.cpp
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart.cpp
@@ -115,8 +115,8 @@ void MitsubishiUART::dump_config() {
     ESP_LOGCONFIG(TAG, "Discovered Capabilities: %s", capabilities_cache_.value().to_string().c_str());
   }
 
-  if (kumo_emulation_mode_) {
-    ESP_LOGCONFIG(TAG, "Kumo Emulation Mode is ENABLED! This is an *experimental mode* and things may break.");
+  if (enhanced_mhk_support_) {
+    ESP_LOGCONFIG(TAG, "MHK Enhanced Protocol Mode is ENABLED! This is currently *experimental* and things may break!");
   }
 }
 
@@ -150,7 +150,7 @@ void MitsubishiUART::update() {
   // autoconf.
   //       For now, just requesting it as part of our "init loops" is a good first step.
   if (!this->capabilities_requested_) {
-    IFACTIVE(hp_bridge_.send_packet(BaseCapabilitiesRequestPacket::instance()); this->capabilities_requested_ = true;)
+    IFACTIVE(hp_bridge_.send_packet(CapabilitiesRequestPacket::instance()); this->capabilities_requested_ = true;)
   }
 
   // Before requesting additional updates, publish any changes waiting from packets received

--- a/esphome/components/mitsubishi_itp/mitsubishi_uart.h
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart.h
@@ -8,6 +8,7 @@
 #include "esphome/components/climate/climate.h"
 #include "esphome/components/select/select.h"
 #include "esphome/components/sensor/sensor.h"
+#include "muart_mhk.h"
 #include "muart_packet.h"
 #include "muart_bridge.h"
 #include <map>
@@ -212,11 +213,7 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   // used to track whether to support/handle the enhanced MHK protocol packets
   bool enhanced_mhk_support_ = false;
 
-  // used to track heat/cool setpoints for parity sync with MHK units.
-  // necessary to not clobber the union of setpoints, since ESPHome doesnt gracefully handle simultaneous cool and
-  // heat setpoints being set.
-  float last_cool_setpoint_ = NAN;
-  float last_heat_setpoint_ = NAN;
+  MHKState mhk_state_;
 };
 
 struct MUARTPreferences {

--- a/esphome/components/mitsubishi_itp/mitsubishi_uart.h
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart.h
@@ -103,6 +103,9 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   // Turns on or off actively sending packets
   void set_active_mode(const bool active) { active_mode_ = active; };
 
+  // Turns on or off Kumo emulation mode
+  void set_kumo_emulation_mode(const bool mode) { kumo_emulation_mode_ = mode; }
+
   void set_time_source(time::RealTimeClock *rtc) { time_source = rtc; }
 
  protected:
@@ -206,6 +209,11 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   void send_if_active_(const Packet &packet);
   bool active_mode_ = true;
 
+  bool kumo_emulation_mode_ = false;
+
+  // used to track heat/cool setpoints for parity sync with MHK units.
+  // necessary to not clobber the union of setpoints, since ESPHome doesnt gracefully handle simultaneous cool and
+  // heat setpoints being set.
   float last_cool_setpoint_ = NAN;
   float last_heat_setpoint_ = NAN;
 };

--- a/esphome/components/mitsubishi_itp/mitsubishi_uart.h
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart.h
@@ -104,9 +104,9 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   void set_active_mode(const bool active) { active_mode_ = active; };
 
   // Turns on or off Kumo emulation mode
-  void set_kumo_emulation_mode(const bool mode) { kumo_emulation_mode_ = mode; }
+  void set_enhanced_mhk_support(const bool mode) { enhanced_mhk_support_ = mode; }
 
-  void set_time_source(time::RealTimeClock *rtc) { time_source = rtc; }
+  void set_time_source(time::RealTimeClock *rtc) { time_source_ = rtc; }
 
  protected:
   void route_packet_(const Packet &packet);
@@ -114,8 +114,8 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   void process_packet(const Packet &packet) override;
   void process_packet(const ConnectRequestPacket &packet) override;
   void process_packet(const ConnectResponsePacket &packet) override;
-  void process_packet(const BaseCapabilitiesRequestPacket &packet) override;
-  void process_packet(const BaseCapabilitiesResponsePacket &packet) override;
+  void process_packet(const CapabilitiesRequestPacket &packet) override;
+  void process_packet(const CapabilitiesResponsePacket &packet) override;
   void process_packet(const GetRequestPacket &packet) override;
   void process_packet(const SettingsGetResponsePacket &packet) override;
   void process_packet(const CurrentTempGetResponsePacket &packet) override;
@@ -124,14 +124,14 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   void process_packet(const ErrorStateGetResponsePacket &packet) override;
   void process_packet(const SettingsSetRequestPacket &packet) override;
   void process_packet(const RemoteTemperatureSetRequestPacket &packet) override;
-  void process_packet(const KumoThermostatSensorStatusPacket &packet) override;
-  void process_packet(const KumoThermostatHelloPacket &packet) override;
-  void process_packet(const KumoThermostatStateSyncPacket &packet) override;
-  void process_packet(const KumoAASetRequestPacket &packet) override;
+  void process_packet(const ThermostatSensorStatusPacket &packet) override;
+  void process_packet(const ThermostatHelloPacket &packet) override;
+  void process_packet(const ThermostatStateUploadPacket &packet) override;
+  void process_packet(const ThermostatAASetRequestPacket &packet) override;
   void process_packet(const SetResponsePacket &packet) override;
 
-  void handle_kumo_adapter_state_get_request(const GetRequestPacket &packet) override;
-  void handle_kumo_aa_get_request(const GetRequestPacket &packet) override;
+  void handle_thermostat_state_download_request(const GetRequestPacket &packet) override;
+  void handle_thermostat_ab_get_request(const GetRequestPacket &packet) override;
 
   void do_publish_();
 
@@ -168,7 +168,7 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   // Number of times update() has been called in discovery mode
   size_t discovery_updates_ = 0;
 
-  optional<BaseCapabilitiesResponsePacket> capabilities_cache_;
+  optional<CapabilitiesResponsePacket> capabilities_cache_;
   bool capabilities_requested_ = false;
   // Have we received at least one RunState response?
   bool run_state_received_ = false;
@@ -180,7 +180,7 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   ESPPreferenceObject preferences_;
 
   // Time Source
-  time::RealTimeClock *time_source = nullptr;
+  time::RealTimeClock *time_source_ = nullptr;
 
   // Internal sensors
   sensor::Sensor *thermostat_temperature_sensor_ = nullptr;
@@ -209,7 +209,8 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   void send_if_active_(const Packet &packet);
   bool active_mode_ = true;
 
-  bool kumo_emulation_mode_ = false;
+  // used to track whether to support/handle the enhanced MHK protocol packets
+  bool enhanced_mhk_support_ = false;
 
   // used to track heat/cool setpoints for parity sync with MHK units.
   // necessary to not clobber the union of setpoints, since ESPHome doesnt gracefully handle simultaneous cool and

--- a/esphome/components/mitsubishi_itp/mitsubishi_uart.h
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart.h
@@ -114,8 +114,8 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   void process_packet(const Packet &packet) override;
   void process_packet(const ConnectRequestPacket &packet) override;
   void process_packet(const ConnectResponsePacket &packet) override;
-  void process_packet(const ExtendedConnectRequestPacket &packet) override;
-  void process_packet(const ExtendedConnectResponsePacket &packet) override;
+  void process_packet(const BaseCapabilitiesRequestPacket &packet) override;
+  void process_packet(const BaseCapabilitiesResponsePacket &packet) override;
   void process_packet(const GetRequestPacket &packet) override;
   void process_packet(const SettingsGetResponsePacket &packet) override;
   void process_packet(const CurrentTempGetResponsePacket &packet) override;
@@ -168,7 +168,7 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   // Number of times update() has been called in discovery mode
   size_t discovery_updates_ = 0;
 
-  optional<ExtendedConnectResponsePacket> capabilities_cache_;
+  optional<BaseCapabilitiesResponsePacket> capabilities_cache_;
   bool capabilities_requested_ = false;
   // Have we received at least one RunState response?
   bool run_state_received_ = false;

--- a/esphome/components/mitsubishi_itp/mitsubishi_uart.h
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart.h
@@ -8,9 +8,9 @@
 #include "esphome/components/climate/climate.h"
 #include "esphome/components/select/select.h"
 #include "esphome/components/sensor/sensor.h"
-#include "muart_mhk.h"
 #include "muart_packet.h"
 #include "muart_bridge.h"
+#include "muart_mhk.h"
 #include <map>
 
 namespace esphome {

--- a/esphome/components/mitsubishi_itp/mitsubishi_uart.h
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart.h
@@ -105,7 +105,7 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   void set_active_mode(const bool active) { active_mode_ = active; };
 
   // Turns on or off Kumo emulation mode
-  void set_enhanced_mhk_support(const bool mode) { enhanced_mhk_support_ = mode; }
+  void set_enhanced_mhk_support(const bool supports) { enhanced_mhk_support_ = supports; }
 
   void set_time_source(time::RealTimeClock *rtc) { time_source_ = rtc; }
 

--- a/esphome/components/mitsubishi_itp/muart_bridge.cpp
+++ b/esphome/components/mitsubishi_itp/muart_bridge.cpp
@@ -173,8 +173,8 @@ void MUARTBridge::classify_and_process_raw_packet_(RawPacket &pkt) const {
         case GetCommand::STATUS:
           process_raw_packet_<StatusGetResponsePacket>(pkt, false);
           break;
-        case GetCommand::A_9:
-          process_raw_packet_<A9GetRequestPacket>(pkt, false);
+        case GetCommand::KUMO_GET_ADAPTER_STATE:
+          process_raw_packet_<KumoCloudStateSyncPacket>(pkt, false);
           break;
         default:
           process_raw_packet_<Packet>(pkt, false);
@@ -188,8 +188,17 @@ void MUARTBridge::classify_and_process_raw_packet_(RawPacket &pkt) const {
         case SetCommand::SETTINGS:
           process_raw_packet_<SettingsSetRequestPacket>(pkt, true);
           break;
-        case SetCommand::THERMOSTAT_HELLO:
-          process_raw_packet_<ThermostatHelloRequestPacket>(pkt, false);
+        case SetCommand::KUMO_THERMOSTAT_SENSOR_STATUS:
+          process_raw_packet_<KumoThermostatSensorStatusPacket>(pkt, true);
+          break;
+        case SetCommand::KUMO_THERMOSTAT_HELLO:
+          process_raw_packet_<KumoThermostatHelloPacket>(pkt, false);
+          break;
+        case SetCommand::KUMO_THERMOSTAT_STATE_SYNC:
+          process_raw_packet_<KumoThermostatStateSyncPacket>(pkt, true);
+          break;
+        case SetCommand::KUMO_AA:
+          process_raw_packet_<KumoAASetRequestPacket>(pkt, true);
           break;
         default:
           process_raw_packet_<Packet>(pkt, true);

--- a/esphome/components/mitsubishi_itp/muart_bridge.cpp
+++ b/esphome/components/mitsubishi_itp/muart_bridge.cpp
@@ -146,11 +146,11 @@ void MUARTBridge::classify_and_process_raw_packet_(RawPacket &pkt) const {
       process_raw_packet_<ConnectResponsePacket>(pkt, false);
       break;
 
-    case PacketType::EXTENDED_CONNECT_REQUEST:
-      process_raw_packet_<ExtendedConnectRequestPacket>(pkt, true);
+    case PacketType::IDENTIFY_REQUEST:
+      process_raw_packet_<BaseCapabilitiesRequestPacket>(pkt, true);
       break;
-    case PacketType::EXTENDED_CONNECT_RESPONSE:
-      process_raw_packet_<ExtendedConnectResponsePacket>(pkt, false);
+    case PacketType::IDENTIFY_RESPONSE:
+      process_raw_packet_<BaseCapabilitiesResponsePacket>(pkt, false);
       break;
 
     case PacketType::GET_REQUEST:

--- a/esphome/components/mitsubishi_itp/muart_bridge.cpp
+++ b/esphome/components/mitsubishi_itp/muart_bridge.cpp
@@ -147,10 +147,10 @@ void MUARTBridge::classify_and_process_raw_packet_(RawPacket &pkt) const {
       break;
 
     case PacketType::IDENTIFY_REQUEST:
-      process_raw_packet_<BaseCapabilitiesRequestPacket>(pkt, true);
+      process_raw_packet_<CapabilitiesRequestPacket>(pkt, true);
       break;
     case PacketType::IDENTIFY_RESPONSE:
-      process_raw_packet_<BaseCapabilitiesResponsePacket>(pkt, false);
+      process_raw_packet_<CapabilitiesResponsePacket>(pkt, false);
       break;
 
     case PacketType::GET_REQUEST:
@@ -173,8 +173,8 @@ void MUARTBridge::classify_and_process_raw_packet_(RawPacket &pkt) const {
         case GetCommand::STATUS:
           process_raw_packet_<StatusGetResponsePacket>(pkt, false);
           break;
-        case GetCommand::KUMO_GET_ADAPTER_STATE:
-          process_raw_packet_<KumoCloudStateSyncPacket>(pkt, false);
+        case GetCommand::THERMOSTAT_STATE_DOWNLOAD:
+          process_raw_packet_<ThermostatStateDownloadResponsePacket>(pkt, false);
           break;
         default:
           process_raw_packet_<Packet>(pkt, false);
@@ -188,17 +188,17 @@ void MUARTBridge::classify_and_process_raw_packet_(RawPacket &pkt) const {
         case SetCommand::SETTINGS:
           process_raw_packet_<SettingsSetRequestPacket>(pkt, true);
           break;
-        case SetCommand::KUMO_THERMOSTAT_SENSOR_STATUS:
-          process_raw_packet_<KumoThermostatSensorStatusPacket>(pkt, true);
+        case SetCommand::THERMOSTAT_SENSOR_STATUS:
+          process_raw_packet_<ThermostatSensorStatusPacket>(pkt, true);
           break;
-        case SetCommand::KUMO_THERMOSTAT_HELLO:
-          process_raw_packet_<KumoThermostatHelloPacket>(pkt, false);
+        case SetCommand::THERMOSTAT_HELLO:
+          process_raw_packet_<ThermostatHelloPacket>(pkt, false);
           break;
-        case SetCommand::KUMO_THERMOSTAT_STATE_SYNC:
-          process_raw_packet_<KumoThermostatStateSyncPacket>(pkt, true);
+        case SetCommand::THERMOSTAT_STATE_UPLOAD:
+          process_raw_packet_<ThermostatStateUploadPacket>(pkt, true);
           break;
-        case SetCommand::KUMO_AA:
-          process_raw_packet_<KumoAASetRequestPacket>(pkt, true);
+        case SetCommand::THERMOSTAT_SET_AA:
+          process_raw_packet_<ThermostatAASetRequestPacket>(pkt, true);
           break;
         default:
           process_raw_packet_<Packet>(pkt, true);

--- a/esphome/components/mitsubishi_itp/muart_mhk.h
+++ b/esphome/components/mitsubishi_itp/muart_mhk.h
@@ -1,0 +1,11 @@
+namespace esphome {
+namespace mitsubishi_itp {
+
+/// A struct that represents the connected MHK's state for management and synchronization purposes.
+struct MHKState {
+  float cool_setpoint_ = NAN;
+  float heat_setpoint_ = NAN;
+};
+
+}  // namespace mitsubishi_itp
+}  // namespace esphome

--- a/esphome/components/mitsubishi_itp/muart_mhk.h
+++ b/esphome/components/mitsubishi_itp/muart_mhk.h
@@ -1,3 +1,8 @@
+#ifndef MITSUBISHIITP_MHK
+#define MITSUBISHIITP_MHK
+
+#include <cmath>
+
 namespace esphome {
 namespace mitsubishi_itp {
 
@@ -9,3 +14,5 @@ struct MHKState {
 
 }  // namespace mitsubishi_itp
 }  // namespace esphome
+
+#endif  // MITSUBISHIITP_MHK

--- a/esphome/components/mitsubishi_itp/muart_mhk.h
+++ b/esphome/components/mitsubishi_itp/muart_mhk.h
@@ -1,5 +1,4 @@
-#ifndef MITSUBISHIITP_MHK
-#define MITSUBISHIITP_MHK
+#pragma once
 
 #include <cmath>
 
@@ -14,5 +13,3 @@ struct MHKState {
 
 }  // namespace mitsubishi_itp
 }  // namespace esphome
-
-#endif  // MITSUBISHIITP_MHK

--- a/esphome/components/mitsubishi_itp/muart_packet-derived.cpp
+++ b/esphome/components/mitsubishi_itp/muart_packet-derived.cpp
@@ -296,19 +296,19 @@ std::string ThermostatHelloPacket::get_thermostat_version_string() const {
 }
 
 // ThermostatStateUploadPacket functions
-int32_t ThermostatStateUploadPacket::get_thermostat_timestamp(esphome::ESPTime *outTimestamp) const {
+time_t ThermostatStateUploadPacket::get_thermostat_timestamp(esphome::ESPTime *out_timestamp) const {
   int32_be_t magic;
   std::memcpy(&magic, pkt_.get_payload_bytes(PLINDEX_THERMOSTAT_TIMESTAMP), 4);
 
-  outTimestamp->second = magic & 63;
-  outTimestamp->minute = (magic >> 6) & 63;
-  outTimestamp->hour = (magic >> 12) & 31;
-  outTimestamp->day_of_month = (magic >> 17) & 31;
-  outTimestamp->month = (magic >> 22) & 15;
-  outTimestamp->year = (magic >> 26) + 2017;
+  out_timestamp->second = magic & 63;
+  out_timestamp->minute = (magic >> 6) & 63;
+  out_timestamp->hour = (magic >> 12) & 31;
+  out_timestamp->day_of_month = (magic >> 17) & 31;
+  out_timestamp->month = (magic >> 22) & 15;
+  out_timestamp->year = (magic >> 26) + 2017;
 
-  outTimestamp->recalc_timestamp_local();
-  return outTimestamp->timestamp;
+  out_timestamp->recalc_timestamp_local();
+  return out_timestamp->timestamp;
 }
 
 uint8_t ThermostatStateUploadPacket::get_auto_mode() const { return pkt_.get_payload_byte(PLINDEX_AUTO_MODE); }

--- a/esphome/components/mitsubishi_itp/muart_packet-derived.cpp
+++ b/esphome/components/mitsubishi_itp/muart_packet-derived.cpp
@@ -10,9 +10,9 @@ namespace mitsubishi_itp {
 
 std::string ConnectRequestPacket::to_string() const { return ("Connect Request: " + Packet::to_string()); }
 std::string ConnectResponsePacket::to_string() const { return ("Connect Response: " + Packet::to_string()); }
-std::string ExtendedConnectResponsePacket::to_string() const {
+std::string BaseCapabilitiesResponsePacket::to_string() const {
   return (
-      "Extended Connect Response: " + Packet::to_string() + CONSOLE_COLOR_PURPLE +
+      "Identify Base Capabilities Response: " + Packet::to_string() + CONSOLE_COLOR_PURPLE +
       "\n HeatDisabled:" + (is_heat_disabled() ? "Yes" : "No") + " SupportsVane:" + (supports_vane() ? "Yes" : "No") +
       " SupportsVaneSwing:" + (supports_vane_swing() ? "Yes" : "No")
 
@@ -28,6 +28,9 @@ std::string ExtendedConnectResponsePacket::to_string() const {
       std::to_string(get_max_cool_dry_setpoint()) + " HeatSetpoint:" + std::to_string(get_min_heating_setpoint()) +
       "/" + std::to_string(get_max_heating_setpoint()) + " AutoSetpoint:" + std::to_string(get_min_auto_setpoint()) +
       "/" + std::to_string(get_max_auto_setpoint()) + " FanSpeeds:" + std::to_string(get_supported_fan_speeds()));
+}
+std::string IdentifyCDResponsePacket::to_string() const {
+  return "Identify CD Response: " + Packet::to_string();
 }
 std::string CurrentTempGetResponsePacket::to_string() const {
   return ("Current Temp Response: " + Packet::to_string() + CONSOLE_COLOR_PURPLE +
@@ -350,8 +353,8 @@ std::string ErrorStateGetResponsePacket::get_short_code() const {
   return {upper_alphabet[(error_code & 0xE0) >> 5], lower_alphabet[low_bits]};
 }
 
-// ExtendedConnectResponsePacket functions
-uint8_t ExtendedConnectResponsePacket::get_supported_fan_speeds() const {
+// BaseCapabilitiesResponsePacket functions
+uint8_t BaseCapabilitiesResponsePacket::get_supported_fan_speeds() const {
   uint8_t raw_value = ((pkt_.get_payload_byte(7) & 0x10) >> 2) + ((pkt_.get_payload_byte(8) & 0x08) >> 2) +
                       ((pkt_.get_payload_byte(9) & 0x02) >> 1);
 
@@ -371,7 +374,7 @@ uint8_t ExtendedConnectResponsePacket::get_supported_fan_speeds() const {
   }
 }
 
-climate::ClimateTraits ExtendedConnectResponsePacket::as_traits() const {
+climate::ClimateTraits BaseCapabilitiesResponsePacket::as_traits() const {
   auto ct = climate::ClimateTraits();
 
   // always enabled

--- a/esphome/components/mitsubishi_itp/muart_packet-derived.cpp
+++ b/esphome/components/mitsubishi_itp/muart_packet-derived.cpp
@@ -95,6 +95,7 @@ std::string ThermostatStateUploadPacket::to_string() const {
     result += " TS Time: " + timestamp.strftime("%Y-%m-%d %H:%M:%S");
   }
 
+  if (flags & TSSF_AUTO_MODE) result += " AutoMode: " + std::to_string(get_auto_mode());
   if (flags & TSSF_HEAT_SETPOINT) result += " HeatSetpoint: " + std::to_string(get_heat_setpoint());
   if (flags & TSSF_COOL_SETPOINT) result += " CoolSetpoint: " + std::to_string(get_cool_setpoint());
 
@@ -304,6 +305,10 @@ int32_t ThermostatStateUploadPacket::get_thermostat_timestamp(esphome::ESPTime *
   return outTimestamp->timestamp;
 }
 
+uint8_t ThermostatStateUploadPacket::get_auto_mode() const {
+  return pkt_.get_payload_byte(PLINDEX_AUTO_MODE);
+}
+
 float ThermostatStateUploadPacket::get_heat_setpoint() const {
   uint8_t enhancedRawTemp = pkt_.get_payload_byte(PLINDEX_HEAT_SETPOINT);
   return MUARTUtils::temp_scale_a_to_deg_c(enhancedRawTemp);
@@ -324,6 +329,11 @@ ThermostatStateDownloadResponsePacket &ThermostatStateDownloadResponsePacket::se
   pkt_.set_payload_bytes(PLINDEX_ADAPTER_TIMESTAMP, &swappedTimestamp, 4);
   pkt_.set_payload_byte(10, 0x07);  // ???
 
+  return *this;
+}
+
+ThermostatStateDownloadResponsePacket &ThermostatStateDownloadResponsePacket::set_auto_mode(bool is_auto) {
+  pkt_.set_payload_byte(PLINDEX_AUTO_MODE, is_auto ? 0x01 : 0x00);
   return *this;
 }
 

--- a/esphome/components/mitsubishi_itp/muart_packet-derived.cpp
+++ b/esphome/components/mitsubishi_itp/muart_packet-derived.cpp
@@ -29,9 +29,7 @@ std::string CapabilitiesResponsePacket::to_string() const {
       "/" + std::to_string(get_max_heating_setpoint()) + " AutoSetpoint:" + std::to_string(get_min_auto_setpoint()) +
       "/" + std::to_string(get_max_auto_setpoint()) + " FanSpeeds:" + std::to_string(get_supported_fan_speeds()));
 }
-std::string IdentifyCDResponsePacket::to_string() const {
-  return "Identify CD Response: " + Packet::to_string();
-}
+std::string IdentifyCDResponsePacket::to_string() const { return "Identify CD Response: " + Packet::to_string(); }
 std::string CurrentTempGetResponsePacket::to_string() const {
   return ("Current Temp Response: " + Packet::to_string() + CONSOLE_COLOR_PURPLE +
           "\n Temp:" + std::to_string(get_current_temp()) +
@@ -72,8 +70,8 @@ std::string RemoteTemperatureSetRequestPacket::to_string() const {
 std::string ThermostatSensorStatusPacket::to_string() const {
   return ("Thermostat Sensor Status: " + Packet::to_string() + CONSOLE_COLOR_PURPLE +
           "\n Indoor RH: " + std::to_string(get_indoor_humidity_percent()) + "%" +
-          "  MHK Battery: " + THERMOSTAT_BATTERY_STATE_NAMES[get_thermostat_battery_state()] +
-          "(" + std::to_string(get_thermostat_battery_state()) + ")" +
+          "  MHK Battery: " + THERMOSTAT_BATTERY_STATE_NAMES[get_thermostat_battery_state()] + "(" +
+          std::to_string(get_thermostat_battery_state()) + ")" +
           "  Sensor Flags: " + std::to_string(get_sensor_flags()));
 }
 
@@ -85,8 +83,8 @@ std::string ThermostatHelloPacket::to_string() const {
 std::string ThermostatStateUploadPacket::to_string() const {
   uint8_t flags = get_flags();
 
-  std::string result = "Thermostat Sync " + Packet::to_string() + CONSOLE_COLOR_PURPLE +
-                       "\n Flags: " + format_hex(flags) + " =>";
+  std::string result =
+      "Thermostat Sync " + Packet::to_string() + CONSOLE_COLOR_PURPLE + "\n Flags: " + format_hex(flags) + " =>";
 
   if (flags & TSSF_TIMESTAMP) {
     ESPTime timestamp{};
@@ -95,9 +93,12 @@ std::string ThermostatStateUploadPacket::to_string() const {
     result += " TS Time: " + timestamp.strftime("%Y-%m-%d %H:%M:%S");
   }
 
-  if (flags & TSSF_AUTO_MODE) result += " AutoMode: " + std::to_string(get_auto_mode());
-  if (flags & TSSF_HEAT_SETPOINT) result += " HeatSetpoint: " + std::to_string(get_heat_setpoint());
-  if (flags & TSSF_COOL_SETPOINT) result += " CoolSetpoint: " + std::to_string(get_cool_setpoint());
+  if (flags & TSSF_AUTO_MODE)
+    result += " AutoMode: " + std::to_string(get_auto_mode());
+  if (flags & TSSF_HEAT_SETPOINT)
+    result += " HeatSetpoint: " + std::to_string(get_heat_setpoint());
+  if (flags & TSSF_COOL_SETPOINT)
+    result += " CoolSetpoint: " + std::to_string(get_cool_setpoint());
 
   return result;
 }
@@ -114,11 +115,16 @@ std::string SettingsSetRequestPacket::to_string() const {
   std::string result = "Settings Set Request: " + Packet::to_string() + CONSOLE_COLOR_PURPLE +
                        "\n Flags: " + format_hex(flags2) + format_hex(flags) + " =>";
 
-  if (flags & SettingFlag::SF_POWER) result += " Power: " + std::to_string(get_power());
-  if (flags & SettingFlag::SF_MODE) result += " Mode: " + std::to_string(get_mode());
-  if (flags & SettingFlag::SF_TARGET_TEMPERATURE) result += " TargetTemp: " + std::to_string(get_target_temp());
-  if (flags & SettingFlag::SF_FAN) result += " Fan: " + std::to_string(get_fan());
-  if (flags & SettingFlag::SF_VANE) result += " Vane: " + std::to_string(get_vane());
+  if (flags & SettingFlag::SF_POWER)
+    result += " Power: " + std::to_string(get_power());
+  if (flags & SettingFlag::SF_MODE)
+    result += " Mode: " + std::to_string(get_mode());
+  if (flags & SettingFlag::SF_TARGET_TEMPERATURE)
+    result += " TargetTemp: " + std::to_string(get_target_temp());
+  if (flags & SettingFlag::SF_FAN)
+    result += " Fan: " + std::to_string(get_fan());
+  if (flags & SettingFlag::SF_VANE)
+    result += " Vane: " + std::to_string(get_vane());
 
   if (flags2 & SettingFlag2::SF2_HORIZONTAL_VANE)
     result += " HVane: " + std::to_string(get_horizontal_vane()) + (get_horizontal_vane_msb() ? " (MSB Set)" : "");
@@ -305,28 +311,26 @@ int32_t ThermostatStateUploadPacket::get_thermostat_timestamp(esphome::ESPTime *
   return outTimestamp->timestamp;
 }
 
-uint8_t ThermostatStateUploadPacket::get_auto_mode() const {
-  return pkt_.get_payload_byte(PLINDEX_AUTO_MODE);
-}
+uint8_t ThermostatStateUploadPacket::get_auto_mode() const { return pkt_.get_payload_byte(PLINDEX_AUTO_MODE); }
 
 float ThermostatStateUploadPacket::get_heat_setpoint() const {
-  uint8_t enhancedRawTemp = pkt_.get_payload_byte(PLINDEX_HEAT_SETPOINT);
-  return MUARTUtils::temp_scale_a_to_deg_c(enhancedRawTemp);
+  uint8_t enhanced_raw_temp = pkt_.get_payload_byte(PLINDEX_HEAT_SETPOINT);
+  return MUARTUtils::temp_scale_a_to_deg_c(enhanced_raw_temp);
 }
 
 float ThermostatStateUploadPacket::get_cool_setpoint() const {
-  uint8_t enhancedRawTemp = pkt_.get_payload_byte(PLINDEX_COOL_SETPOINT);
-  return MUARTUtils::temp_scale_a_to_deg_c(enhancedRawTemp);
+  uint8_t enhanced_raw_temp = pkt_.get_payload_byte(PLINDEX_COOL_SETPOINT);
+  return MUARTUtils::temp_scale_a_to_deg_c(enhanced_raw_temp);
 }
 
 // ThermostatStateDownloadResponsePacket functions
 ThermostatStateDownloadResponsePacket &ThermostatStateDownloadResponsePacket::set_timestamp(esphome::ESPTime ts) {
-  int32_t encodedTimestamp = ((ts.year - 2017) << 26) | (ts.month << 22) | (ts.day_of_month << 17) |
-                                    (ts.hour << 12) | (ts.minute << 6) | (ts.second);
+  int32_t encoded_timestamp = ((ts.year - 2017) << 26) | (ts.month << 22) | (ts.day_of_month << 17) | (ts.hour << 12) |
+                              (ts.minute << 6) | (ts.second);
 
-  int32_t swappedTimestamp = byteswap(encodedTimestamp);
+  int32_t swapped_timestamp = byteswap(encoded_timestamp);
 
-  pkt_.set_payload_bytes(PLINDEX_ADAPTER_TIMESTAMP, &swappedTimestamp, 4);
+  pkt_.set_payload_bytes(PLINDEX_ADAPTER_TIMESTAMP, &swapped_timestamp, 4);
   pkt_.set_payload_byte(10, 0x07);  // ???
 
   return *this;
@@ -337,15 +341,15 @@ ThermostatStateDownloadResponsePacket &ThermostatStateDownloadResponsePacket::se
   return *this;
 }
 
-ThermostatStateDownloadResponsePacket &ThermostatStateDownloadResponsePacket::set_heat_setpoint(float highTemp) {
-  uint8_t temp_a = highTemp != NAN ? MUARTUtils::deg_c_to_temp_scale_a(highTemp) : 0x00;
+ThermostatStateDownloadResponsePacket &ThermostatStateDownloadResponsePacket::set_heat_setpoint(float high_temp) {
+  uint8_t temp_a = high_temp != NAN ? MUARTUtils::deg_c_to_temp_scale_a(high_temp) : 0x00;
 
   pkt_.set_payload_byte(PLINDEX_HEAT_SETPOINT, temp_a);
   return *this;
 }
 
-ThermostatStateDownloadResponsePacket &ThermostatStateDownloadResponsePacket::set_cool_setpoint(float lowTemp) {
-  uint8_t temp_a = lowTemp != NAN ? MUARTUtils::deg_c_to_temp_scale_a(lowTemp) : 0x00;
+ThermostatStateDownloadResponsePacket &ThermostatStateDownloadResponsePacket::set_cool_setpoint(float low_temp) {
+  uint8_t temp_a = low_temp != NAN ? MUARTUtils::deg_c_to_temp_scale_a(low_temp) : 0x00;
 
   pkt_.set_payload_byte(PLINDEX_COOL_SETPOINT, temp_a);
   return *this;

--- a/esphome/components/mitsubishi_itp/muart_packet-derived.cpp
+++ b/esphome/components/mitsubishi_itp/muart_packet-derived.cpp
@@ -145,23 +145,23 @@ SettingsSetRequestPacket &SettingsSetRequestPacket::set_mode(const ModeByte mode
   return *this;
 }
 
-SettingsSetRequestPacket &SettingsSetRequestPacket::set_target_temperature(const float temperature_degress_c) {
-  if (temperature_degress_c < 63.5 && temperature_degress_c > -64.0) {
-    pkt_.set_payload_byte(PLINDEX_TARGET_TEMPERATURE, MUARTUtils::deg_c_to_temp_scale_a(temperature_degress_c));
+SettingsSetRequestPacket &SettingsSetRequestPacket::set_target_temperature(const float temperature_degrees_c) {
+  if (temperature_degrees_c < 63.5 && temperature_degrees_c > -64.0) {
+    pkt_.set_payload_byte(PLINDEX_TARGET_TEMPERATURE, MUARTUtils::deg_c_to_temp_scale_a(temperature_degrees_c));
     pkt_.set_payload_byte(PLINDEX_TARGET_TEMPERATURE_CODE,
-                          MUARTUtils::deg_c_to_legacy_target_temp(temperature_degress_c));
+                          MUARTUtils::deg_c_to_legacy_target_temp(temperature_degrees_c));
 
     // TODO: while spawning a warning here is fine, we should (a) only actually send that warning if the system can't
     //       support this setpoint, and (b) clamp the setpoint to the known-acceptable values.
     // The utility class will already clamp this for us, so we only need to worry about the warning.
-    if (temperature_degress_c < 16 || temperature_degress_c > 31.5) {
+    if (temperature_degrees_c < 16 || temperature_degrees_c > 31.5) {
       ESP_LOGW(PTAG, "Target temp %f is out of range for the legacy temp scale. This may be a problem on older units.",
-               temperature_degress_c);
+               temperature_degrees_c);
     }
 
     add_settings_flag_(SF_TARGET_TEMPERATURE);
   } else {
-    ESP_LOGW(PTAG, "Target temp %f is outside valid range - target temperature not set!", temperature_degress_c);
+    ESP_LOGW(PTAG, "Target temp %f is outside valid range - target temperature not set!", temperature_degrees_c);
   }
 
   return *this;
@@ -229,14 +229,14 @@ float RemoteTemperatureSetRequestPacket::get_remote_temperature() const {
 }
 
 RemoteTemperatureSetRequestPacket &RemoteTemperatureSetRequestPacket::set_remote_temperature(
-    float temperature_degress_c) {
-  if (temperature_degress_c < 63.5 && temperature_degress_c > -64.0) {
-    pkt_.set_payload_byte(PLINDEX_REMOTE_TEMPERATURE, MUARTUtils::deg_c_to_temp_scale_a(temperature_degress_c));
+    float temperature_degrees_c) {
+  if (temperature_degrees_c < 63.5 && temperature_degrees_c > -64.0) {
+    pkt_.set_payload_byte(PLINDEX_REMOTE_TEMPERATURE, MUARTUtils::deg_c_to_temp_scale_a(temperature_degrees_c));
     pkt_.set_payload_byte(PLINDEX_LEGACY_REMOTE_TEMPERATURE,
-                          MUARTUtils::deg_c_to_legacy_room_temp(temperature_degress_c));
+                          MUARTUtils::deg_c_to_legacy_room_temp(temperature_degrees_c));
     set_flags(0x01);  // Set flags to say we're providing the temperature
   } else {
-    ESP_LOGW(PTAG, "Remote temp %f is outside valid range.", temperature_degress_c);
+    ESP_LOGW(PTAG, "Remote temp %f is outside valid range.", temperature_degrees_c);
   }
   return *this;
 }
@@ -245,7 +245,7 @@ RemoteTemperatureSetRequestPacket &RemoteTemperatureSetRequestPacket::use_intern
   return *this;
 }
 
-// SettingsSetRunStatisPacket functions
+// SettingsSetRunStatusPacket functions
 SetRunStatePacket &SetRunStatePacket::set_filter_reset(bool do_reset) {
   pkt_.set_payload_byte(PLINDEX_FILTER_RESET, do_reset ? 1 : 0);
   set_flags(0x01);

--- a/esphome/components/mitsubishi_itp/muart_packet.h
+++ b/esphome/components/mitsubishi_itp/muart_packet.h
@@ -486,7 +486,7 @@ class ThermostatStateUploadPacket : public Packet {
     pkt_.set_payload_byte(0, static_cast<uint8_t>(SetCommand::THERMOSTAT_STATE_UPLOAD));
   }
 
-  int32_t get_thermostat_timestamp(ESPTime *outTimestamp) const;
+  time_t get_thermostat_timestamp(esphome::ESPTime *out_timestamp) const;
   uint8_t get_auto_mode() const;
   float get_heat_setpoint() const;
   float get_cool_setpoint() const;

--- a/esphome/components/mitsubishi_itp/muart_packet.h
+++ b/esphome/components/mitsubishi_itp/muart_packet.h
@@ -102,9 +102,7 @@ class CapabilitiesRequestPacket : public Packet {
   using Packet::Packet;
 
  private:
-  CapabilitiesRequestPacket() : Packet(RawPacket(PacketType::IDENTIFY_REQUEST, 1)) {
-    pkt_.set_payload_byte(0, 0xc9);
-  }
+  CapabilitiesRequestPacket() : Packet(RawPacket(PacketType::IDENTIFY_REQUEST, 1)) { pkt_.set_payload_byte(0, 0xc9); }
 };
 
 class CapabilitiesResponsePacket : public Packet {
@@ -158,9 +156,7 @@ class IdentifyCDRequestPacket : public Packet {
   using Packet::Packet;
 
  private:
-  IdentifyCDRequestPacket() : Packet(RawPacket(PacketType::IDENTIFY_REQUEST, 1)) {
-    pkt_.set_payload_byte(0, 0xCD);
-  }
+  IdentifyCDRequestPacket() : Packet(RawPacket(PacketType::IDENTIFY_REQUEST, 1)) { pkt_.set_payload_byte(0, 0xCD); }
 };
 
 class IdentifyCDResponsePacket : public Packet {
@@ -363,7 +359,9 @@ class SettingsSetRequestPacket : public Packet {
   ModeByte get_mode() const { return (ModeByte) pkt_.get_payload_byte(PLINDEX_MODE); }
   FanByte get_fan() const { return (FanByte) pkt_.get_payload_byte(PLINDEX_FAN); }
   VaneByte get_vane() const { return (VaneByte) pkt_.get_payload_byte(PLINDEX_VANE); }
-  HorizontalVaneByte get_horizontal_vane() const { return (HorizontalVaneByte) (pkt_.get_payload_byte(PLINDEX_HORIZONTAL_VANE) & 0x7F); }
+  HorizontalVaneByte get_horizontal_vane() const {
+    return (HorizontalVaneByte) (pkt_.get_payload_byte(PLINDEX_HORIZONTAL_VANE) & 0x7F);
+  }
   bool get_horizontal_vane_msb() const { return pkt_.get_payload_byte(PLINDEX_HORIZONTAL_VANE) & 0x80; }
 
   float get_target_temp() const;
@@ -442,7 +440,9 @@ class ThermostatSensorStatusPacket : public Packet {
   }
 
   uint8_t get_indoor_humidity_percent() const { return pkt_.get_payload_byte(5); }
-  ThermostatBatteryState get_thermostat_battery_state() const { return (ThermostatBatteryState) pkt_.get_payload_byte(6); }
+  ThermostatBatteryState get_thermostat_battery_state() const {
+    return (ThermostatBatteryState) pkt_.get_payload_byte(6);
+  }
   uint8_t get_sensor_flags() const { return pkt_.get_payload_byte(7); }
 
   std::string to_string() const override;
@@ -486,7 +486,7 @@ class ThermostatStateUploadPacket : public Packet {
     pkt_.set_payload_byte(0, static_cast<uint8_t>(SetCommand::THERMOSTAT_STATE_UPLOAD));
   }
 
-  int32_t get_thermostat_timestamp(ESPTime* outTimestamp) const;
+  int32_t get_thermostat_timestamp(ESPTime *outTimestamp) const;
   uint8_t get_auto_mode() const;
   float get_heat_setpoint() const;
   float get_cool_setpoint() const;
@@ -509,8 +509,8 @@ class ThermostatStateDownloadResponsePacket : public Packet {
 
   ThermostatStateDownloadResponsePacket &set_timestamp(ESPTime ts);
   ThermostatStateDownloadResponsePacket &set_auto_mode(bool is_auto);
-  ThermostatStateDownloadResponsePacket &set_heat_setpoint(float highTemp);
-  ThermostatStateDownloadResponsePacket &set_cool_setpoint(float lowTemp);
+  ThermostatStateDownloadResponsePacket &set_heat_setpoint(float high_temp);
+  ThermostatStateDownloadResponsePacket &set_cool_setpoint(float low_temp);
 };
 
 class ThermostatAASetRequestPacket : public Packet {

--- a/esphome/components/mitsubishi_itp/muart_packet.h
+++ b/esphome/components/mitsubishi_itp/muart_packet.h
@@ -91,23 +91,23 @@ class ConnectResponsePacket : public Packet {
 };
 
 ////
-// Extended Connect
+// Identify packets
 ////
-class ExtendedConnectRequestPacket : public Packet {
+class BaseCapabilitiesRequestPacket : public Packet {
  public:
-  static ExtendedConnectRequestPacket &instance() {
-    static ExtendedConnectRequestPacket instance;
+  static BaseCapabilitiesRequestPacket &instance() {
+    static BaseCapabilitiesRequestPacket instance;
     return instance;
   }
   using Packet::Packet;
 
  private:
-  ExtendedConnectRequestPacket() : Packet(RawPacket(PacketType::EXTENDED_CONNECT_REQUEST, 1)) {
+  BaseCapabilitiesRequestPacket() : Packet(RawPacket(PacketType::IDENTIFY_REQUEST, 1)) {
     pkt_.set_payload_byte(0, 0xc9);
   }
 };
 
-class ExtendedConnectResponsePacket : public Packet {
+class BaseCapabilitiesResponsePacket : public Packet {
   using Packet::Packet;
 
  public:
@@ -146,6 +146,27 @@ class ExtendedConnectResponsePacket : public Packet {
   // This will also not handle things like MHK2 humidity detection.
   climate::ClimateTraits as_traits() const;
 
+  std::string to_string() const override;
+};
+
+class IdentifyCDRequestPacket : public Packet {
+ public:
+  static IdentifyCDRequestPacket &instance() {
+    static IdentifyCDRequestPacket instance;
+    return instance;
+  }
+  using Packet::Packet;
+
+ private:
+  IdentifyCDRequestPacket() : Packet(RawPacket(PacketType::IDENTIFY_REQUEST, 1)) {
+    pkt_.set_payload_byte(0, 0xCD);
+  }
+};
+
+class IdentifyCDResponsePacket : public Packet {
+  using Packet::Packet;
+
+ public:
   std::string to_string() const override;
 };
 
@@ -511,8 +532,8 @@ class PacketProcessor {
   virtual void process_packet(const Packet &packet){};
   virtual void process_packet(const ConnectRequestPacket &packet){};
   virtual void process_packet(const ConnectResponsePacket &packet){};
-  virtual void process_packet(const ExtendedConnectRequestPacket &packet){};
-  virtual void process_packet(const ExtendedConnectResponsePacket &packet){};
+  virtual void process_packet(const BaseCapabilitiesRequestPacket &packet){};
+  virtual void process_packet(const BaseCapabilitiesResponsePacket &packet){};
   virtual void process_packet(const GetRequestPacket &packet){};
   virtual void process_packet(const SettingsGetResponsePacket &packet){};
   virtual void process_packet(const CurrentTempGetResponsePacket &packet){};

--- a/esphome/components/mitsubishi_itp/muart_packet.h
+++ b/esphome/components/mitsubishi_itp/muart_packet.h
@@ -27,7 +27,7 @@ class Packet {
   Packet(RawPacket &&pkt) : pkt_(pkt){};  // TODO: Confirm this needs std::move if call to constructor ALSO has move
   Packet();                               // For optional<> construction
 
-  // Returns a (more) human readable string of the packet
+  // Returns a (more) human-readable string of the packet
   virtual std::string to_string() const;
 
   // Is a response packet expected when this packet is sent.  Defaults to true since
@@ -370,7 +370,7 @@ class SettingsSetRequestPacket : public Packet {
 
   SettingsSetRequestPacket &set_power(bool is_on);
   SettingsSetRequestPacket &set_mode(ModeByte mode);
-  SettingsSetRequestPacket &set_target_temperature(float temperature_degress_c);
+  SettingsSetRequestPacket &set_target_temperature(float temperature_degrees_c);
   SettingsSetRequestPacket &set_fan(FanByte fan);
   SettingsSetRequestPacket &set_vane(VaneByte vane);
   SettingsSetRequestPacket &set_horizontal_vane(HorizontalVaneByte horizontal_vane);
@@ -394,7 +394,7 @@ class RemoteTemperatureSetRequestPacket : public Packet {
 
   float get_remote_temperature() const;
 
-  RemoteTemperatureSetRequestPacket &set_remote_temperature(float temperature_degress_c);
+  RemoteTemperatureSetRequestPacket &set_remote_temperature(float temperature_degrees_c);
   RemoteTemperatureSetRequestPacket &use_internal_temperature();
 
   std::string to_string() const override;

--- a/esphome/components/mitsubishi_itp/muart_packet.h
+++ b/esphome/components/mitsubishi_itp/muart_packet.h
@@ -93,21 +93,21 @@ class ConnectResponsePacket : public Packet {
 ////
 // Identify packets
 ////
-class BaseCapabilitiesRequestPacket : public Packet {
+class CapabilitiesRequestPacket : public Packet {
  public:
-  static BaseCapabilitiesRequestPacket &instance() {
-    static BaseCapabilitiesRequestPacket instance;
+  static CapabilitiesRequestPacket &instance() {
+    static CapabilitiesRequestPacket instance;
     return instance;
   }
   using Packet::Packet;
 
  private:
-  BaseCapabilitiesRequestPacket() : Packet(RawPacket(PacketType::IDENTIFY_REQUEST, 1)) {
+  CapabilitiesRequestPacket() : Packet(RawPacket(PacketType::IDENTIFY_REQUEST, 1)) {
     pkt_.set_payload_byte(0, 0xc9);
   }
 };
 
-class BaseCapabilitiesResponsePacket : public Packet {
+class CapabilitiesResponsePacket : public Packet {
   using Packet::Packet;
 
  public:
@@ -425,7 +425,7 @@ class SetRunStatePacket : public Packet {
   SetRunStatePacket &set_filter_reset(bool do_reset);
 };
 
-class KumoThermostatSensorStatusPacket : public Packet {
+class ThermostatSensorStatusPacket : public Packet {
   using Packet::Packet;
 
  public:
@@ -437,8 +437,8 @@ class KumoThermostatSensorStatusPacket : public Packet {
     THERMOSTAT_BATTERY_UNKNOWN = 0x04,
   };
 
-  KumoThermostatSensorStatusPacket() : Packet(RawPacket(PacketType::SET_REQUEST, 16)) {
-    pkt_.set_payload_byte(0, static_cast<uint8_t>(SetCommand::KUMO_THERMOSTAT_SENSOR_STATUS));
+  ThermostatSensorStatusPacket() : Packet(RawPacket(PacketType::SET_REQUEST, 16)) {
+    pkt_.set_payload_byte(0, static_cast<uint8_t>(SetCommand::THERMOSTAT_SENSOR_STATUS));
   }
 
   uint8_t get_indoor_humidity_percent() const { return pkt_.get_payload_byte(5); }
@@ -449,12 +449,12 @@ class KumoThermostatSensorStatusPacket : public Packet {
 };
 
 // Sent by MHK2 but with no response; defined to allow setResponseExpected(false)
-class KumoThermostatHelloPacket : public Packet {
+class ThermostatHelloPacket : public Packet {
   using Packet::Packet;
 
  public:
-  KumoThermostatHelloPacket() : Packet(RawPacket(PacketType::SET_REQUEST, 16)) {
-    pkt_.set_payload_byte(0, static_cast<uint8_t>(SetCommand::KUMO_THERMOSTAT_HELLO));
+  ThermostatHelloPacket() : Packet(RawPacket(PacketType::SET_REQUEST, 16)) {
+    pkt_.set_payload_byte(0, static_cast<uint8_t>(SetCommand::THERMOSTAT_HELLO));
   }
 
   std::string get_thermostat_model() const;
@@ -464,7 +464,7 @@ class KumoThermostatHelloPacket : public Packet {
   std::string to_string() const override;
 };
 
-class KumoThermostatStateSyncPacket : public Packet {
+class ThermostatStateUploadPacket : public Packet {
   // Packet 0x41 - AG 0xA8
 
   static const uint8_t PLINDEX_THERMOSTAT_TIMESTAMP = 2;
@@ -480,8 +480,8 @@ class KumoThermostatStateSyncPacket : public Packet {
   using Packet::Packet;
 
  public:
-  KumoThermostatStateSyncPacket() : Packet(RawPacket(PacketType::SET_REQUEST, 16)) {
-    pkt_.set_payload_byte(0, static_cast<uint8_t>(SetCommand::KUMO_THERMOSTAT_STATE_SYNC));
+  ThermostatStateUploadPacket() : Packet(RawPacket(PacketType::SET_REQUEST, 16)) {
+    pkt_.set_payload_byte(0, static_cast<uint8_t>(SetCommand::THERMOSTAT_STATE_UPLOAD));
   }
 
   int32_t get_thermostat_timestamp(ESPTime* outTimestamp) const;
@@ -491,38 +491,38 @@ class KumoThermostatStateSyncPacket : public Packet {
   std::string to_string() const override;
 };
 
-class KumoCloudStateSyncPacket : public Packet {
-  static const uint8_t PLINDEX_KUMOCLOUD_TIMESTAMP = 1;
+class ThermostatStateDownloadResponsePacket : public Packet {
+  static const uint8_t PLINDEX_ADAPTER_TIMESTAMP = 1;
   static const uint8_t PLINDEX_HEAT_SETPOINT = 7;
   static const uint8_t PLINDEX_COOL_SETPOINT = 8;
 
   using Packet::Packet;
 
  public:
-  KumoCloudStateSyncPacket() : Packet(RawPacket(PacketType::GET_RESPONSE, 16)) {
-    pkt_.set_payload_byte(0, static_cast<uint8_t>(GetCommand::KUMO_GET_ADAPTER_STATE));
+  ThermostatStateDownloadResponsePacket() : Packet(RawPacket(PacketType::GET_RESPONSE, 16)) {
+    pkt_.set_payload_byte(0, static_cast<uint8_t>(GetCommand::THERMOSTAT_STATE_DOWNLOAD));
   }
 
-  KumoCloudStateSyncPacket &set_timestamp(ESPTime ts);
-  KumoCloudStateSyncPacket &set_heat_setpoint(float highTemp);
-  KumoCloudStateSyncPacket &set_cool_setpoint(float lowTemp);
+  ThermostatStateDownloadResponsePacket &set_timestamp(ESPTime ts);
+  ThermostatStateDownloadResponsePacket &set_heat_setpoint(float highTemp);
+  ThermostatStateDownloadResponsePacket &set_cool_setpoint(float lowTemp);
 };
 
-class KumoAASetRequestPacket : public Packet {
+class ThermostatAASetRequestPacket : public Packet {
   using Packet::Packet;
 
  public:
-  KumoAASetRequestPacket() : Packet(RawPacket(PacketType::SET_REQUEST, 16)) {
-    pkt_.set_payload_byte(0, static_cast<uint8_t>(SetCommand::KUMO_AA));
+  ThermostatAASetRequestPacket() : Packet(RawPacket(PacketType::SET_REQUEST, 16)) {
+    pkt_.set_payload_byte(0, static_cast<uint8_t>(SetCommand::THERMOSTAT_SET_AA));
   }
 };
 
-class KumoABGetRequestPacket : public Packet {
+class ThermostatABGetResponsePacket : public Packet {
   using Packet::Packet;
 
  public:
-  KumoABGetRequestPacket() : Packet(RawPacket(PacketType::GET_RESPONSE, 16)) {
-    pkt_.set_payload_byte(0, static_cast<uint8_t>(GetCommand::KUMO_AB));
+  ThermostatABGetResponsePacket() : Packet(RawPacket(PacketType::GET_RESPONSE, 16)) {
+    pkt_.set_payload_byte(0, static_cast<uint8_t>(GetCommand::THERMOSTAT_GET_AB));
     pkt_.set_payload_byte(1, 1);
   }
 };
@@ -532,8 +532,8 @@ class PacketProcessor {
   virtual void process_packet(const Packet &packet){};
   virtual void process_packet(const ConnectRequestPacket &packet){};
   virtual void process_packet(const ConnectResponsePacket &packet){};
-  virtual void process_packet(const BaseCapabilitiesRequestPacket &packet){};
-  virtual void process_packet(const BaseCapabilitiesResponsePacket &packet){};
+  virtual void process_packet(const CapabilitiesRequestPacket &packet){};
+  virtual void process_packet(const CapabilitiesResponsePacket &packet){};
   virtual void process_packet(const GetRequestPacket &packet){};
   virtual void process_packet(const SettingsGetResponsePacket &packet){};
   virtual void process_packet(const CurrentTempGetResponsePacket &packet){};
@@ -542,16 +542,16 @@ class PacketProcessor {
   virtual void process_packet(const ErrorStateGetResponsePacket &packet){};
   virtual void process_packet(const SettingsSetRequestPacket &packet){};
   virtual void process_packet(const RemoteTemperatureSetRequestPacket &packet){};
-  virtual void process_packet(const KumoThermostatSensorStatusPacket &packet){};
-  virtual void process_packet(const KumoThermostatHelloPacket &packet){};
-  virtual void process_packet(const KumoThermostatStateSyncPacket &packet){};
-  virtual void process_packet(const KumoCloudStateSyncPacket &packet){};
-  virtual void process_packet(const KumoAASetRequestPacket &packet){};
-  virtual void process_packet(const KumoABGetRequestPacket &packet){};
+  virtual void process_packet(const ThermostatSensorStatusPacket &packet){};
+  virtual void process_packet(const ThermostatHelloPacket &packet){};
+  virtual void process_packet(const ThermostatStateUploadPacket &packet){};
+  virtual void process_packet(const ThermostatStateDownloadResponsePacket &packet){};
+  virtual void process_packet(const ThermostatAASetRequestPacket &packet){};
+  virtual void process_packet(const ThermostatABGetResponsePacket &packet){};
   virtual void process_packet(const SetResponsePacket &packet){};
 
-  virtual void handle_kumo_adapter_state_get_request(const GetRequestPacket &packet){};
-  virtual void handle_kumo_aa_get_request(const GetRequestPacket &packet){};
+  virtual void handle_thermostat_state_download_request(const GetRequestPacket &packet){};
+  virtual void handle_thermostat_ab_get_request(const GetRequestPacket &packet){};
 };
 
 }  // namespace mitsubishi_itp

--- a/esphome/components/mitsubishi_itp/muart_packet.h
+++ b/esphome/components/mitsubishi_itp/muart_packet.h
@@ -468,11 +468,13 @@ class ThermostatStateUploadPacket : public Packet {
   // Packet 0x41 - AG 0xA8
 
   static const uint8_t PLINDEX_THERMOSTAT_TIMESTAMP = 2;
+  static const uint8_t PLINDEX_AUTO_MODE = 7;
   static const uint8_t PLINDEX_HEAT_SETPOINT = 8;
   static const uint8_t PLINDEX_COOL_SETPOINT = 9;
 
   enum TSStateSyncFlags : uint8_t {
     TSSF_TIMESTAMP = 0x01,
+    TSSF_AUTO_MODE = 0x04,
     TSSF_HEAT_SETPOINT = 0x08,
     TSSF_COOL_SETPOINT = 0x10,
   };
@@ -485,6 +487,7 @@ class ThermostatStateUploadPacket : public Packet {
   }
 
   int32_t get_thermostat_timestamp(ESPTime* outTimestamp) const;
+  uint8_t get_auto_mode() const;
   float get_heat_setpoint() const;
   float get_cool_setpoint() const;
 
@@ -493,6 +496,7 @@ class ThermostatStateUploadPacket : public Packet {
 
 class ThermostatStateDownloadResponsePacket : public Packet {
   static const uint8_t PLINDEX_ADAPTER_TIMESTAMP = 1;
+  static const uint8_t PLINDEX_AUTO_MODE = 6;
   static const uint8_t PLINDEX_HEAT_SETPOINT = 7;
   static const uint8_t PLINDEX_COOL_SETPOINT = 8;
 
@@ -504,6 +508,7 @@ class ThermostatStateDownloadResponsePacket : public Packet {
   }
 
   ThermostatStateDownloadResponsePacket &set_timestamp(ESPTime ts);
+  ThermostatStateDownloadResponsePacket &set_auto_mode(bool is_auto);
   ThermostatStateDownloadResponsePacket &set_heat_setpoint(float highTemp);
   ThermostatStateDownloadResponsePacket &set_cool_setpoint(float lowTemp);
 };

--- a/esphome/components/mitsubishi_itp/muart_rawpacket.cpp
+++ b/esphome/components/mitsubishi_itp/muart_rawpacket.cpp
@@ -60,5 +60,11 @@ RawPacket &RawPacket::set_payload_byte(const uint8_t payload_byte_index, const u
   return *this;
 }
 
+RawPacket &RawPacket::set_payload_bytes(const uint8_t begin_index, const void* value, const size_t size) {
+  memcpy(&packet_bytes_[PACKET_HEADER_SIZE + begin_index], value, size);
+  update_checksum_();
+  return *this;
+}
+
 }  // namespace mitsubishi_itp
 }  // namespace esphome

--- a/esphome/components/mitsubishi_itp/muart_rawpacket.cpp
+++ b/esphome/components/mitsubishi_itp/muart_rawpacket.cpp
@@ -37,7 +37,7 @@ RawPacket::RawPacket() {
   // TODO: Is this okay?
 }
 
-uint8_t RawPacket::calculate_checksum_() const {
+uint8_t RawPacket::calculate_checksum_() const {  // NOLINT(readability-identifier-naming)
   uint8_t sum = 0;
   for (int i = 0; i < checksum_index_; i++) {
     sum += packet_bytes_[i];
@@ -60,7 +60,7 @@ RawPacket &RawPacket::set_payload_byte(const uint8_t payload_byte_index, const u
   return *this;
 }
 
-RawPacket &RawPacket::set_payload_bytes(const uint8_t begin_index, const void* value, const size_t size) {
+RawPacket &RawPacket::set_payload_bytes(const uint8_t begin_index, const void *value, const size_t size) {
   memcpy(&packet_bytes_[PACKET_HEADER_SIZE + begin_index], value, size);
   update_checksum_();
   return *this;

--- a/esphome/components/mitsubishi_itp/muart_rawpacket.h
+++ b/esphome/components/mitsubishi_itp/muart_rawpacket.h
@@ -100,7 +100,9 @@ class RawPacket {
   uint8_t get_payload_byte(const uint8_t payload_byte_index) const {
     return packet_bytes_[PACKET_HEADER_SIZE + payload_byte_index];
   };
-  const uint8_t *get_payload_bytes(size_t startIndex = 0) const { return &packet_bytes_[PACKET_HEADER_SIZE + startIndex]; }
+  const uint8_t *get_payload_bytes(size_t startIndex = 0) const {
+    return &packet_bytes_[PACKET_HEADER_SIZE + startIndex];
+  }
 
  private:
   static const int PLINDEX_COMMAND = 0;

--- a/esphome/components/mitsubishi_itp/muart_rawpacket.h
+++ b/esphome/components/mitsubishi_itp/muart_rawpacket.h
@@ -100,8 +100,8 @@ class RawPacket {
   uint8_t get_payload_byte(const uint8_t payload_byte_index) const {
     return packet_bytes_[PACKET_HEADER_SIZE + payload_byte_index];
   };
-  const uint8_t *get_payload_bytes(size_t startIndex = 0) const {
-    return &packet_bytes_[PACKET_HEADER_SIZE + startIndex];
+  const uint8_t *get_payload_bytes(size_t start_index = 0) const {
+    return &packet_bytes_[PACKET_HEADER_SIZE + start_index];
   }
 
  private:

--- a/esphome/components/mitsubishi_itp/muart_rawpacket.h
+++ b/esphome/components/mitsubishi_itp/muart_rawpacket.h
@@ -24,8 +24,8 @@ enum class PacketType : uint8_t {
   GET_RESPONSE = 0x62,
   SET_REQUEST = 0x41,
   SET_RESPONSE = 0x61,
-  EXTENDED_CONNECT_REQUEST = 0x5b,
-  EXTENDED_CONNECT_RESPONSE = 0x7b
+  IDENTIFY_REQUEST = 0x5b,
+  IDENTIFY_RESPONSE = 0x7b
 };
 
 // Used to specify certain packet subtypes

--- a/esphome/components/mitsubishi_itp/muart_rawpacket.h
+++ b/esphome/components/mitsubishi_itp/muart_rawpacket.h
@@ -35,8 +35,8 @@ enum class GetCommand : uint8_t {
   ERROR_INFO = 0x04,
   STATUS = 0x06,
   RUN_STATE = 0x09,
-  KUMO_GET_ADAPTER_STATE = 0xa9,
-  KUMO_AB = 0xab,
+  THERMOSTAT_STATE_DOWNLOAD = 0xa9,
+  THERMOSTAT_GET_AB = 0xab,
 };
 
 // Used to specify certain packet subtypes
@@ -44,10 +44,10 @@ enum class SetCommand : uint8_t {
   SETTINGS = 0x01,
   REMOTE_TEMPERATURE = 0x07,
   RUN_STATE = 0x08,
-  KUMO_THERMOSTAT_SENSOR_STATUS = 0xa6,
-  KUMO_THERMOSTAT_HELLO = 0xa7,
-  KUMO_THERMOSTAT_STATE_SYNC = 0xa8,
-  KUMO_AA = 0xaa,
+  THERMOSTAT_SENSOR_STATUS = 0xa6,
+  THERMOSTAT_HELLO = 0xa7,
+  THERMOSTAT_STATE_UPLOAD = 0xa8,
+  THERMOSTAT_SET_AA = 0xaa,
 };
 
 // Which MUARTBridge was the packet read from (used to determine flow direction of the packet)

--- a/esphome/components/mitsubishi_itp/muart_rawpacket.h
+++ b/esphome/components/mitsubishi_itp/muart_rawpacket.h
@@ -35,7 +35,8 @@ enum class GetCommand : uint8_t {
   ERROR_INFO = 0x04,
   STATUS = 0x06,
   RUN_STATE = 0x09,
-  A_9 = 0xa9
+  KUMO_GET_ADAPTER_STATE = 0xa9,
+  KUMO_AB = 0xab,
 };
 
 // Used to specify certain packet subtypes
@@ -43,7 +44,10 @@ enum class SetCommand : uint8_t {
   SETTINGS = 0x01,
   REMOTE_TEMPERATURE = 0x07,
   RUN_STATE = 0x08,
-  THERMOSTAT_HELLO = 0xa7
+  KUMO_THERMOSTAT_SENSOR_STATUS = 0xa6,
+  KUMO_THERMOSTAT_HELLO = 0xa7,
+  KUMO_THERMOSTAT_STATE_SYNC = 0xa8,
+  KUMO_AA = 0xaa,
 };
 
 // Which MUARTBridge was the packet read from (used to determine flow direction of the packet)
@@ -92,9 +96,11 @@ class RawPacket {
   ControllerAssociation get_controller_association() const { return controller_association_; };
 
   RawPacket &set_payload_byte(uint8_t payload_byte_index, uint8_t value);
+  RawPacket &set_payload_bytes(uint8_t begin_index, const void *value, size_t size);
   uint8_t get_payload_byte(const uint8_t payload_byte_index) const {
     return packet_bytes_[PACKET_HEADER_SIZE + payload_byte_index];
   };
+  const uint8_t *get_payload_bytes(size_t startIndex = 0) const { return &packet_bytes_[PACKET_HEADER_SIZE + startIndex]; }
 
  private:
   static const int PLINDEX_COMMAND = 0;

--- a/tests/components/mitsubishi_itp/common.yaml
+++ b/tests/components/mitsubishi_itp/common.yaml
@@ -1,3 +1,14 @@
+wifi:
+  ssid: MySSID
+  password: password1
+
+api:
+
+time:
+  - platform: homeassistant
+    id: homeassistant_time
+    timezone: America/Los_Angeles
+
 sensor:
   - platform: template
     id: fake_temp
@@ -25,6 +36,7 @@ climate:
   - platform: mitsubishi_itp
     uart_heatpump: hp_uart
     uart_thermostat: tstat_uart
+    time_source: homeassistant_time
     update_interval: 12s
     temperature_sources:
       - fake_temp


### PR DESCRIPTION
> [!CAUTION]
> This code is *not* production ready. Certain values are hardcoded to observed states with no knowledge on what those hardcoded values actually mean or do. 
> 
> This code has only been tested with two specific units (`MSZ-FS06NA` and `SVZ-KP30NA`) on MHK2 firmware version 01.00.01. 
>
> As such, I have included a disabled-by-default flag to the config to explicitly enable this mode for interested users.

This pull request aims to add Kumo emulation support to the mUART stack, and expose some Kumo specific information.

- Send appropriate responses to `A?` packets sent by an MHK. Slot in known data when we have it.
- Process and expose certain data from the MHK units.
  - Adds sync for low/high setpoints (even though this does nothing for now)
  - Add humidity and battery state sensors for the thermostat.
- Add a requirement for a time source if an MHK is connected.
  - Required for time syncing between ESP and MHK. I don't want to deal with edge cases with invalid time.
- Fix the thermostat hello decoder, which had endianness issues.

This PR still needs:

- [ ] Additional documentation on what certain fields do (or setting them to zero if safe)
- [ ] (Possibly) Some way to expose the model/serial/version info
- [ ] More RE work to try to catch extra fields.

If desired, we can strip out all the sensors/set functionality and stub everything out for just protocol level support. This would make MHK mode effectively transparent, though I suspect we'd still need to report some parameters.