### PR TITLE
Fix an obvious typo, swap STATUS with STANDBY

### DIFF
--- a/esphome/components/mitsubishi_uart/muart_packet.h
+++ b/esphome/components/mitsubishi_uart/muart_packet.h
@@ -160,11 +160,11 @@ class GetRequestPacket : public Packet {
     return instance;
   }
   static GetRequestPacket &get_status_instance() {
-    static GetRequestPacket instance = GetRequestPacket(GetCommand::STANDBY);
+    static GetRequestPacket instance = GetRequestPacket(GetCommand::STATUS);
     return instance;
   }
   static GetRequestPacket &get_standby_instance() {
-    static GetRequestPacket instance = GetRequestPacket(GetCommand::STATUS);
+    static GetRequestPacket instance = GetRequestPacket(GetCommand::STANDBY);
     return instance;
   }
   static GetRequestPacket &get_error_info_instance() {


### PR DESCRIPTION
These were opposite:
`get_status_instance`  -> `GetRequestPacket(GetCommand::STATUS)`
`get_standby_instance` -> `GetRequestPacket(GetCommand::STANDBY)`

No real implications other than status/standby commands being sent in the opposite order than they were coded, which shouldn't matter.