### PR TITLE
Add Filter Reset Button

### DIFF
--- a/esphome/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
+++ b/esphome/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
@@ -265,14 +265,14 @@ void MitsubishiUART::process_packet(const StatusGetResponsePacket &packet) {
     publish_on_update_ |= (old_compressor_frequency != compressor_frequency_sensor_->raw_state);
   }
 };
-void MitsubishiUART::process_packet(const StandbyGetResponsePacket &packet) {
+void MitsubishiUART::process_packet(const RunStateGetResponsePacket &packet) {
   ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
   route_packet_(packet);
 
-  if (service_filter_sensor_) {
-    const bool old_service_filter = service_filter_sensor_->state;
-    service_filter_sensor_->state = packet.service_filter();
-    publish_on_update_ |= (old_service_filter != service_filter_sensor_->state);
+  if (filter_status_sensor_) {
+    const bool old_service_filter = filter_status_sensor_->state;
+    filter_status_sensor_->state = packet.service_filter();
+    publish_on_update_ |= (old_service_filter != filter_status_sensor_->state);
   }
 
   if (defrost_sensor_) {

--- a/esphome/components/mitsubishi_uart/mitsubishi_uart.cpp
+++ b/esphome/components/mitsubishi_uart/mitsubishi_uart.cpp
@@ -162,7 +162,7 @@ void MitsubishiUART::update() {
       //       cadence, depending on their utility (e.g. we dont need to check for errors every loop).
       hp_bridge_.send_packet(
           GetRequestPacket::get_settings_instance());  // Needs to be done before status packet for mode logic to work
-      hp_bridge_.send_packet(GetRequestPacket::get_standby_instance());
+      hp_bridge_.send_packet(GetRequestPacket::get_runstate_instance());
       hp_bridge_.send_packet(GetRequestPacket::get_status_instance());
       hp_bridge_.send_packet(GetRequestPacket::get_current_temp_instance());
       hp_bridge_.send_packet(GetRequestPacket::get_error_info_instance());)
@@ -199,7 +199,7 @@ void MitsubishiUART::do_publish_() {
   }
 
   // Binary sensors automatically dedup publishes (I think) and so will only actually publish on change
-  service_filter_sensor_->publish_state(service_filter_sensor_->state);
+  filter_status_sensor_->publish_state(filter_status_sensor_->state);
   defrost_sensor_->publish_state(defrost_sensor_->state);
   hot_adjust_sensor_->publish_state(hot_adjust_sensor_->state);
   standby_sensor_->publish_state(standby_sensor_->state);
@@ -310,6 +310,16 @@ void MitsubishiUART::temperature_source_report(const std::string &temperature_so
       temperature_source_select_->publish_state(temperature_source);
     }
   }
+}
+
+void MitsubishiUART::reset_filter_status() {
+  ESP_LOGI(TAG, "Received a request to reset the filter status.");
+
+  IFNOTACTIVE(return;)
+
+  SetRunStatePacket pkt = SetRunStatePacket();
+  pkt.set_filter_reset(true);
+  hp_bridge_.send_packet(pkt);
 }
 
 }  // namespace mitsubishi_uart

--- a/esphome/components/mitsubishi_uart/mitsubishi_uart.h
+++ b/esphome/components/mitsubishi_uart/mitsubishi_uart.h
@@ -70,7 +70,7 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   void set_thermostat_temperature_sensor(sensor::Sensor *sensor) { thermostat_temperature_sensor_ = sensor; };
   void set_compressor_frequency_sensor(sensor::Sensor *sensor) { compressor_frequency_sensor_ = sensor; };
   void set_actual_fan_sensor(text_sensor::TextSensor *sensor) { actual_fan_sensor_ = sensor; };
-  void set_service_filter_sensor(binary_sensor::BinarySensor *sensor) { service_filter_sensor_ = sensor; };
+  void set_filter_status_sensor(binary_sensor::BinarySensor *sensor) { filter_status_sensor_ = sensor; };
   void set_defrost_sensor(binary_sensor::BinarySensor *sensor) { defrost_sensor_ = sensor; };
   void set_hot_adjust_sensor(binary_sensor::BinarySensor *sensor) { hot_adjust_sensor_ = sensor; };
   void set_standby_sensor(binary_sensor::BinarySensor *sensor) { standby_sensor_ = sensor; };
@@ -91,6 +91,9 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   // Used by external sources to report a temperature
   void temperature_source_report(const std::string &temperature_source, const float &v);
 
+  // Button triggers
+  void reset_filter_status();
+
   // Turns on or off actively sending packets
   void set_active_mode(const bool active) { active_mode_ = active; };
 
@@ -106,7 +109,7 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   void process_packet(const SettingsGetResponsePacket &packet) override;
   void process_packet(const CurrentTempGetResponsePacket &packet) override;
   void process_packet(const StatusGetResponsePacket &packet) override;
-  void process_packet(const StandbyGetResponsePacket &packet) override;
+  void process_packet(const RunStateGetResponsePacket &packet) override;
   void process_packet(const ErrorStateGetResponsePacket &packet) override;
   void process_packet(const RemoteTemperatureSetRequestPacket &packet) override;
   void process_packet(const SetResponsePacket &packet) override;
@@ -155,7 +158,7 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   sensor::Sensor *thermostat_temperature_sensor_ = nullptr;
   sensor::Sensor *compressor_frequency_sensor_ = nullptr;
   text_sensor::TextSensor *actual_fan_sensor_ = nullptr;
-  binary_sensor::BinarySensor *service_filter_sensor_ = nullptr;
+  binary_sensor::BinarySensor *filter_status_sensor_ = nullptr;
   binary_sensor::BinarySensor *defrost_sensor_ = nullptr;
   binary_sensor::BinarySensor *hot_adjust_sensor_ = nullptr;
   binary_sensor::BinarySensor *standby_sensor_ = nullptr;

--- a/esphome/components/mitsubishi_uart/muart_bridge.cpp
+++ b/esphome/components/mitsubishi_uart/muart_bridge.cpp
@@ -167,8 +167,8 @@ void MUARTBridge::classify_and_process_raw_packet_(RawPacket &pkt) const {
         case GetCommand::ERROR_INFO:
           process_raw_packet_<ErrorStateGetResponsePacket>(pkt, false);
           break;
-        case GetCommand::STANDBY:
-          process_raw_packet_<StandbyGetResponsePacket>(pkt, false);
+        case GetCommand::RUN_STATE:
+          process_raw_packet_<RunStateGetResponsePacket>(pkt, false);
           break;
         case GetCommand::STATUS:
           process_raw_packet_<StatusGetResponsePacket>(pkt, false);

--- a/esphome/components/mitsubishi_uart/muart_button.h
+++ b/esphome/components/mitsubishi_uart/muart_button.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "esphome/components/button/button.h"
+#include "mitsubishi_uart.h"
+
+namespace esphome {
+namespace mitsubishi_uart {
+
+class MUARTButton : public button::Button, public Component, public Parented<MitsubishiUART> {
+ public:
+  MUARTButton() = default;
+  using Parented<MitsubishiUART>::Parented;
+
+ protected:
+  virtual void press_action() override;
+};
+
+class FilterResetButton : public MUARTButton {
+ protected:
+  void press_action() { this->parent_->reset_filter_status(); }
+};
+
+}  // namespace mitsubishi_uart
+}  // namespace esphome

--- a/esphome/components/mitsubishi_uart/muart_packet-derived.cpp
+++ b/esphome/components/mitsubishi_uart/muart_packet-derived.cpp
@@ -43,8 +43,8 @@ std::string SettingsGetResponsePacket::to_string() const {
           "\n PowerLock:" + (locked_power() ? "Yes" : "No") + " ModeLock:" + (locked_mode() ? "Yes" : "No") +
           " TempLock:" + (locked_temp() ? "Yes" : "No"));
 }
-std::string StandbyGetResponsePacket::to_string() const {
-  return ("Standby Response: " + Packet::to_string() + CONSOLE_COLOR_PURPLE +
+std::string RunStateGetResponsePacket::to_string() const {
+  return ("RunState Response: " + Packet::to_string() + CONSOLE_COLOR_PURPLE +
           "\n ServiceFilter:" + (service_filter() ? "Yes" : "No") + " Defrost:" + (in_defrost() ? "Yes" : "No") +
           " HotAdjust:" + (in_hot_adjust() ? "Yes" : "No") + " Standby:" + (in_standby() ? "Yes" : "No") +
           " ActualFan:" + ACTUAL_FAN_SPEED_NAMES[get_actual_fan_speed()] + " (" +
@@ -175,6 +175,13 @@ RemoteTemperatureSetRequestPacket &RemoteTemperatureSetRequestPacket::set_remote
 }
 RemoteTemperatureSetRequestPacket &RemoteTemperatureSetRequestPacket::use_internal_temperature() {
   set_flags(0x00);  // Set flags to say to use internal temperature
+  return *this;
+}
+
+// SettingsSetRunStatisPacket functions
+SetRunStatePacket &SetRunStatePacket::set_filter_reset(bool do_reset) {
+  pkt_.set_payload_byte(PLINDEX_FILTER_RESET, do_reset ? 1 : 0);
+  set_flags(0x01);
   return *this;
 }
 

--- a/esphome/components/mitsubishi_uart/muart_rawpacket.h
+++ b/esphome/components/mitsubishi_uart/muart_rawpacket.h
@@ -34,12 +34,17 @@ enum class GetCommand : uint8_t {
   CURRENT_TEMP = 0x03,
   ERROR_INFO = 0x04,
   STATUS = 0x06,
-  STANDBY = 0x09,
+  RUN_STATE = 0x09,
   A_9 = 0xa9
 };
 
 // Used to specify certain packet subtypes
-enum class SetCommand : uint8_t { SETTINGS = 0x01, REMOTE_TEMPERATURE = 0x07, THERMOSTAT_HELLO = 0xa7 };
+enum class SetCommand : uint8_t {
+  SETTINGS = 0x01,
+  REMOTE_TEMPERATURE = 0x07,
+  RUN_STATE = 0x08,
+  THERMOSTAT_HELLO = 0xa7
+};
 
 // Which MUARTBridge was the packet read from (used to determine flow direction of the packet)
 enum class SourceBridge { NONE, HEATPUMP, THERMOSTAT };


### PR DESCRIPTION
(Basically a duplicate of [this PR](https://github.com/Sammy1Am/mitsubishi-uart/pull/40) from the old repo)

- Added a Filter Reset button
- Renamed "Service Filter" sensor to "Filter Status" and made it a "problem" class
- Renamed "Standby" packet to "RunState" packet to more accurately identify it

I successfully tested the Filter Reset button on my SVZ-KP30NA.