### PR TITLE
Stop sending RunState requests if unsupported

### DIFF
--- a/esphome/components/mitsubishi_itp/mitsubishi_uart-packetprocessing.cpp
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart-packetprocessing.cpp
@@ -269,7 +269,7 @@ void MitsubishiUART::process_packet(const RunStateGetResponsePacket &packet) {
   ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
   route_packet_(packet);
 
-  failed_run_state_requests_ = 0;  // Reset this since we received one
+  run_state_received_ = true;  // Set this since we received one
 
   if (filter_status_sensor_) {
     const bool old_service_filter = filter_status_sensor_->state;

--- a/esphome/components/mitsubishi_itp/mitsubishi_uart-packetprocessing.cpp
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart-packetprocessing.cpp
@@ -269,6 +269,8 @@ void MitsubishiUART::process_packet(const RunStateGetResponsePacket &packet) {
   ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
   route_packet_(packet);
 
+  failed_run_state_requests_ = 0;  // Reset this since we received one
+
   if (filter_status_sensor_) {
     const bool old_service_filter = filter_status_sensor_->state;
     filter_status_sensor_->state = packet.service_filter();

--- a/esphome/components/mitsubishi_itp/mitsubishi_uart.cpp
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart.cpp
@@ -162,7 +162,10 @@ void MitsubishiUART::update() {
       //       cadence, depending on their utility (e.g. we dont need to check for errors every loop).
       hp_bridge_.send_packet(
           GetRequestPacket::get_settings_instance());  // Needs to be done before status packet for mode logic to work
-      hp_bridge_.send_packet(GetRequestPacket::get_runstate_instance());
+      if (failed_run_state_requests_++ < 5) {
+        hp_bridge_.send_packet(GetRequestPacket::get_runstate_instance());
+      } else if (failed_run_state_requests_ == 5) { ESP_LOGI(TAG, "Run State packets not supported on this unit."); }
+
       hp_bridge_.send_packet(GetRequestPacket::get_status_instance());
       hp_bridge_.send_packet(GetRequestPacket::get_current_temp_instance());
       hp_bridge_.send_packet(GetRequestPacket::get_error_info_instance());)

--- a/esphome/components/mitsubishi_itp/mitsubishi_uart.h
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart.h
@@ -144,10 +144,15 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   bool hp_connected_ = false;
   // Should we call publish on the next update?
   bool publish_on_update_ = false;
+  // Are we still discovering information about the device?
+  bool in_discovery_ = true;
+  // Number of times update() has been called in discovery mode
+  size_t discovery_updates_ = 0;
 
   optional<ExtendedConnectResponsePacket> capabilities_cache_;
   bool capabilities_requested_ = false;
-  uint8_t failed_run_state_requests_ = 0;
+  // Have we received at least one RunState response?
+  bool run_state_received_ = false;
 
   // Preferences
   void save_preferences_();

--- a/esphome/components/mitsubishi_itp/mitsubishi_uart.h
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart.h
@@ -147,6 +147,7 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
 
   optional<ExtendedConnectResponsePacket> capabilities_cache_;
   bool capabilities_requested_ = false;
+  uint8_t failed_run_state_requests_ = 0;
 
   // Preferences
   void save_preferences_();


### PR DESCRIPTION
Some hardware doesn't support the RunState (`0x09`) packet request.  This change adds a `discovery_mode` that will send requests for RunState for the first 5 updates, but then cease if no responses have been received.

This should resolve #23 .

The new `discovery_mode` will likely come in handy as we attempt to handle capability detection (#13), or other functions that need to take place only during startup but aren't needed once things have settled (installer functions likely included).