### PR TITLE
Validate UART config to prevent misconfiguration errors

### DIFF
--- a/esphome/components/mitsubishi_itp/climate.py
+++ b/esphome/components/mitsubishi_itp/climate.py
@@ -292,6 +292,34 @@ CONFIG_SCHEMA = BASE_SCHEMA.extend(
 )
 
 
+def final_validate(config):
+    schema = uart.final_validate_device_schema(
+        "mitsubishi_itp",
+        uart_bus=CONF_UART_HEATPUMP,
+        require_tx=True,
+        require_rx=True,
+        data_bits=8,
+        parity="EVEN",
+        stop_bits=1,
+    )
+    if CONF_UART_THERMOSTAT in config:
+        schema = schema.extend(
+            uart.final_validate_device_schema(
+                "mitsubishi_itp",
+                uart_bus=CONF_UART_THERMOSTAT,
+                require_tx=True,
+                require_rx=True,
+                data_bits=8,
+                parity="EVEN",
+                stop_bits=1,
+            )
+        )
+    schema(config)
+
+
+FINAL_VALIDATE_SCHEMA = final_validate
+
+
 @coroutine
 async def to_code(config):
     hp_uart_component = await cg.get_variable(config[CONF_UART_HEATPUMP])


### PR DESCRIPTION
Use uart.final_validate_device_schema() to validate the passed UARTs:
* Validate that rx/tx have been given (require_rx/tx) as we know the component won't work otherwise.
* Allow setting the baud rate freely, as we know this varies between models
* Only allow stop_bits=1, data_bits=8 and EVEN parity.