### PR TITLE
Restore last target temperature on ClimateCall mode switch

### DIFF
--- a/esphome/components/mitsubishi_itp/mitsubishi_uart-climatecall.cpp
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart-climatecall.cpp
@@ -80,11 +80,11 @@ void MitsubishiUART::control(const climate::ClimateCall &call) {
     set_request_packet.set_target_temperature(call.get_target_temperature().value());
   } else if (call.get_mode().has_value()) {
     // If we didn't get a new target temp, but we did get a mode, use the last known target temp:
-    auto previous_target = last_mode_target_temperature_.find(call.get_mode().value());
-    if (previous_target != last_mode_target_temperature_.end()) {
-      ESP_LOGD(TAG, "Loading previous target temp %f", previous_target->second);
-      target_temperature = previous_target->second;
-      set_request_packet.set_target_temperature(previous_target->second);
+    auto previous_target = last_mode_target_temperatures_[call.get_mode().value()];
+    if (previous_target > 0) {
+      ESP_LOGD(TAG, "Loading previous target temp %f", previous_target);
+      target_temperature = previous_target;
+      set_request_packet.set_target_temperature(previous_target);
     }
   }
 

--- a/esphome/components/mitsubishi_itp/mitsubishi_uart-packetprocessing.cpp
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart-packetprocessing.cpp
@@ -121,7 +121,7 @@ void MitsubishiUART::process_packet(const SettingsGetResponsePacket &packet) {
         mode = climate::CLIMATE_MODE_OFF;
     }
 
-    last_mode_target_temperature_[mode] = target_temperature;
+    last_mode_target_temperatures_[mode] = target_temperature;
   } else {
     mode = climate::CLIMATE_MODE_OFF;
   }

--- a/esphome/components/mitsubishi_itp/mitsubishi_uart.cpp
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart.cpp
@@ -44,30 +44,7 @@ void MitsubishiUART::save_preferences_() {
     prefs.currentTemperatureSourceIndex = index->second;
   }
 
-  auto lmtt = last_mode_target_temperature_.find(climate::CLIMATE_MODE_HEAT_COOL);
-  if (lmtt != last_mode_target_temperature_.end()) {
-    prefs.lastHeatCoolTargetTemperature = lmtt->second;
-  }
-
-  lmtt = last_mode_target_temperature_.find(climate::CLIMATE_MODE_COOL);
-  if (lmtt != last_mode_target_temperature_.end()) {
-    prefs.lastCoolTargetTemperature = lmtt->second;
-  }
-
-  lmtt = last_mode_target_temperature_.find(climate::CLIMATE_MODE_HEAT);
-  if (lmtt != last_mode_target_temperature_.end()) {
-    prefs.lastHeatTargetTemperature = lmtt->second;
-  }
-
-  lmtt = last_mode_target_temperature_.find(climate::CLIMATE_MODE_FAN_ONLY);
-  if (lmtt != last_mode_target_temperature_.end()) {
-    prefs.lastFanTargetTemperature = lmtt->second;
-  }
-
-  lmtt = last_mode_target_temperature_.find(climate::CLIMATE_MODE_DRY);
-  if (lmtt != last_mode_target_temperature_.end()) {
-    prefs.lastDryTargetTemperature = lmtt->second;
-  }
+  prefs.lastModeTargetTemperatures = last_mode_target_temperatures_;
 
   preferences_.save(&prefs);
 }
@@ -90,21 +67,15 @@ void MitsubishiUART::restore_preferences_() {
     }
 
     // lastModeTargetTemperatures
-    if (prefs.lastHeatCoolTargetTemperature.has_value()) {
-      last_mode_target_temperature_[climate::CLIMATE_MODE_HEAT_COOL] = prefs.lastHeatCoolTargetTemperature.value();
+    for (auto i = 0; i < MAX_MODE_INDEX; i++) {
+      if (prefs.lastModeTargetTemperatures[i] > 0) {
+        // If any targets have been set, assume valid preferences and load them
+        last_mode_target_temperatures_ = prefs.lastModeTargetTemperatures;
+        ESP_LOGCONFIG(TAG, "Last Mode Target Temperatures preference loaded.");
+        break;
+      }
     }
-    if (prefs.lastCoolTargetTemperature.has_value()) {
-      last_mode_target_temperature_[climate::CLIMATE_MODE_COOL] = prefs.lastCoolTargetTemperature.value();
-    }
-    if (prefs.lastHeatTargetTemperature.has_value()) {
-      last_mode_target_temperature_[climate::CLIMATE_MODE_HEAT] = prefs.lastHeatTargetTemperature.value();
-    }
-    if (prefs.lastFanTargetTemperature.has_value()) {
-      last_mode_target_temperature_[climate::CLIMATE_MODE_FAN_ONLY] = prefs.lastFanTargetTemperature.value();
-    }
-    if (prefs.lastDryTargetTemperature.has_value()) {
-      last_mode_target_temperature_[climate::CLIMATE_MODE_DRY] = prefs.lastDryTargetTemperature.value();
-    }
+
   } else {
     // TODO: Shouldn't need to define setting all these defaults twice
     ESP_LOGCONFIG(TAG, "Preferences not loaded.");

--- a/esphome/components/mitsubishi_itp/mitsubishi_uart.cpp
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart.cpp
@@ -44,6 +44,31 @@ void MitsubishiUART::save_preferences_() {
     prefs.currentTemperatureSourceIndex = index->second;
   }
 
+  auto lmtt = last_mode_target_temperature_.find(climate::CLIMATE_MODE_HEAT_COOL);
+  if (lmtt != last_mode_target_temperature_.end()) {
+    prefs.lastHeatCoolTargetTemperature = lmtt->second;
+  }
+
+  lmtt = last_mode_target_temperature_.find(climate::CLIMATE_MODE_COOL);
+  if (lmtt != last_mode_target_temperature_.end()) {
+    prefs.lastCoolTargetTemperature = lmtt->second;
+  }
+
+  lmtt = last_mode_target_temperature_.find(climate::CLIMATE_MODE_HEAT);
+  if (lmtt != last_mode_target_temperature_.end()) {
+    prefs.lastHeatTargetTemperature = lmtt->second;
+  }
+
+  lmtt = last_mode_target_temperature_.find(climate::CLIMATE_MODE_FAN_ONLY);
+  if (lmtt != last_mode_target_temperature_.end()) {
+    prefs.lastFanTargetTemperature = lmtt->second;
+  }
+
+  lmtt = last_mode_target_temperature_.find(climate::CLIMATE_MODE_DRY);
+  if (lmtt != last_mode_target_temperature_.end()) {
+    prefs.lastDryTargetTemperature = lmtt->second;
+  }
+
   preferences_.save(&prefs);
 }
 
@@ -57,11 +82,28 @@ void MitsubishiUART::restore_preferences_() {
         temperature_source_select_->at(prefs.currentTemperatureSourceIndex.value()).has_value()) {
       current_temperature_source_ = temperature_source_select_->at(prefs.currentTemperatureSourceIndex.value()).value();
       temperature_source_select_->publish_state(current_temperature_source_);
-      ESP_LOGCONFIG(TAG, "Preferences loaded.");
+      ESP_LOGCONFIG(TAG, "Current Temperature Source preference loaded.");
     } else {
-      ESP_LOGCONFIG(TAG, "Preferences loaded, but unsuitable values.");
+      ESP_LOGCONFIG(TAG, "Current Temperature Source preference loaded, but unsuitable values.");
       current_temperature_source_ = TEMPERATURE_SOURCE_INTERNAL;
       temperature_source_select_->publish_state(TEMPERATURE_SOURCE_INTERNAL);
+    }
+
+    // lastModeTargetTemperatures
+    if (prefs.lastHeatCoolTargetTemperature.has_value()) {
+      last_mode_target_temperature_[climate::CLIMATE_MODE_HEAT_COOL] = prefs.lastHeatCoolTargetTemperature.value();
+    }
+    if (prefs.lastCoolTargetTemperature.has_value()) {
+      last_mode_target_temperature_[climate::CLIMATE_MODE_COOL] = prefs.lastCoolTargetTemperature.value();
+    }
+    if (prefs.lastHeatTargetTemperature.has_value()) {
+      last_mode_target_temperature_[climate::CLIMATE_MODE_HEAT] = prefs.lastHeatTargetTemperature.value();
+    }
+    if (prefs.lastFanTargetTemperature.has_value()) {
+      last_mode_target_temperature_[climate::CLIMATE_MODE_FAN_ONLY] = prefs.lastFanTargetTemperature.value();
+    }
+    if (prefs.lastDryTargetTemperature.has_value()) {
+      last_mode_target_temperature_[climate::CLIMATE_MODE_DRY] = prefs.lastDryTargetTemperature.value();
     }
   } else {
     // TODO: Shouldn't need to define setting all these defaults twice
@@ -207,8 +249,7 @@ void MitsubishiUART::do_publish_() {
     ESP_LOGI(TAG, "Outdoor temp differs, do publish");
     outdoor_temperature_sensor_->publish_state(outdoor_temperature_sensor_->raw_state);
   }
-  if (thermostat_humidity_sensor_ &&
-      (thermostat_humidity_sensor_->raw_state != thermostat_humidity_sensor_->state)) {
+  if (thermostat_humidity_sensor_ && (thermostat_humidity_sensor_->raw_state != thermostat_humidity_sensor_->state)) {
     ESP_LOGI(TAG, "Thermostat humidity differs, do publish");
     thermostat_humidity_sensor_->publish_state(thermostat_humidity_sensor_->raw_state);
   }

--- a/esphome/components/mitsubishi_itp/mitsubishi_uart.h
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart.h
@@ -214,12 +214,19 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   bool enhanced_mhk_support_ = false;
 
   MHKState mhk_state_;
+
+  std::map<climate::ClimateMode, float> last_mode_target_temperature_;
 };
 
 struct MUARTPreferences {
   optional<size_t> currentTemperatureSourceIndex = nullopt;  // Index of selected value
   // optional<uint32_t> currentTemperatureSourceHash = nullopt; // Hash of selected value (to make sure it hasn't
   // changed since last save)
+  optional<float> lastHeatCoolTargetTemperature = nullopt;
+  optional<float> lastCoolTargetTemperature = nullopt;
+  optional<float> lastHeatTargetTemperature = nullopt;
+  optional<float> lastFanTargetTemperature = nullopt;
+  optional<float> lastDryTargetTemperature = nullopt;
 };
 
 }  // namespace mitsubishi_itp

--- a/esphome/components/mitsubishi_itp/mitsubishi_uart.h
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart.h
@@ -36,6 +36,8 @@ const std::array<std::string, 7> ACTUAL_FAN_SPEED_NAMES = {"Off",  "Very Low",  
 
 const std::array<std::string, 5> THERMOSTAT_BATTERY_STATE_NAMES = {"OK", "Low", "Critical", "Replace", "Unknown"};
 
+const auto MAX_MODE_INDEX = 1 + climate::ClimateMode::CLIMATE_MODE_AUTO;  // Update if more modes are added
+
 class MitsubishiUART : public PollingComponent, public climate::Climate, public PacketProcessor {
  public:
   /**
@@ -215,18 +217,15 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
 
   MHKState mhk_state_;
 
-  std::map<climate::ClimateMode, float> last_mode_target_temperature_;
+  std::array<float, MAX_MODE_INDEX> last_mode_target_temperatures_;  // Update if modes higher
+                                                                     // than AUTO are added
 };
 
 struct MUARTPreferences {
   optional<size_t> currentTemperatureSourceIndex = nullopt;  // Index of selected value
   // optional<uint32_t> currentTemperatureSourceHash = nullopt; // Hash of selected value (to make sure it hasn't
   // changed since last save)
-  optional<float> lastHeatCoolTargetTemperature = nullopt;
-  optional<float> lastCoolTargetTemperature = nullopt;
-  optional<float> lastHeatTargetTemperature = nullopt;
-  optional<float> lastFanTargetTemperature = nullopt;
-  optional<float> lastDryTargetTemperature = nullopt;
+  std::array<float, MAX_MODE_INDEX> lastModeTargetTemperatures;
 };
 
 }  // namespace mitsubishi_itp


### PR DESCRIPTION
When handling a ClimateCall with a defined `mode` but no `target_temperature`, use the last-set target temperature for that mode.  Update "last-set target temperature" every time the target temperature is received from the heatpump.

Desired behavior:
- Clicking the "Mode" button in HA to change mode will automatically change the target temperature to where it was last set for that mode.
- **ANY** explicit change to target temperature should override this behavior
  - From HA: Target temperature in ClimateCall takes precedence
  - From MHK: Target temperature is set directly without ClimateCall logic and "last-set" will be updated on refresh from heat pump
  - From IR: "Last-set" will be updated on refresh from heat pump