### PR TITLE
Pr Changes

### DIFF
--- a/esphome/components/mitsubishi_itp/button/__init__.py
+++ b/esphome/components/mitsubishi_itp/button/__init__.py
@@ -1,0 +1,49 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import button
+from esphome.const import (
+    ENTITY_CATEGORY_CONFIG,
+)
+from esphome.components.mitsubishi_itp.climate import (
+    CONF_MITSUBISHI_IPT_ID,
+    mitsubishi_itp_ns,
+    MitsubishiUART,
+)
+from esphome.core import coroutine
+
+CONF_FILTER_RESET_BUTTON = "filter_reset_button"
+
+FilterResetButton = mitsubishi_itp_ns.class_(
+    "FilterResetButton", button.Button, cg.Component
+)
+
+BUTTONS = {
+    CONF_FILTER_RESET_BUTTON: button.button_schema(
+        FilterResetButton,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        icon="mdi:restore",
+    ),
+}
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_MITSUBISHI_IPT_ID): cv.use_id(MitsubishiUART),
+    }
+).extend(
+    {
+        cv.Optional(button_designator): button_schema
+        for button_designator, button_schema in BUTTONS.items()
+    }
+)
+
+
+@coroutine
+async def to_code(config):
+    muart_component = await cg.get_variable(config[CONF_MITSUBISHI_IPT_ID])
+
+    # Buttons
+    for button_designator, _ in BUTTONS.items():
+        button_conf = config[button_designator]
+        button_component = await button.new_button(button_conf)
+        await cg.register_component(button_component, button_conf)
+        await cg.register_parented(button_component, muart_component)

--- a/esphome/components/mitsubishi_itp/button/__init__.py
+++ b/esphome/components/mitsubishi_itp/button/__init__.py
@@ -1,13 +1,13 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import button
-from esphome.const import (
-    ENTITY_CATEGORY_CONFIG,
-)
 from esphome.components.mitsubishi_itp.climate import (
     CONF_MITSUBISHI_IPT_ID,
     mitsubishi_itp_ns,
     MitsubishiUART,
+)
+from esphome.const import (
+    ENTITY_CATEGORY_CONFIG,
 )
 from esphome.core import coroutine
 

--- a/esphome/components/mitsubishi_itp/button/__init__.py
+++ b/esphome/components/mitsubishi_itp/button/__init__.py
@@ -1,15 +1,15 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import button
-from esphome.components.mitsubishi_itp.climate import (
-    CONF_MITSUBISHI_IPT_ID,
-    mitsubishi_itp_ns,
-    MitsubishiUART,
-)
 from esphome.const import (
     ENTITY_CATEGORY_CONFIG,
 )
 from esphome.core import coroutine
+from ...mitsubishi_itp.climate import (
+    CONF_MITSUBISHI_ITP_ID,
+    mitsubishi_itp_ns,
+    MitsubishiUART,
+)
 
 CONF_FILTER_RESET_BUTTON = "filter_reset_button"
 
@@ -27,7 +27,7 @@ BUTTONS = {
 
 CONFIG_SCHEMA = cv.Schema(
     {
-        cv.GenerateID(CONF_MITSUBISHI_IPT_ID): cv.use_id(MitsubishiUART),
+        cv.GenerateID(CONF_MITSUBISHI_ITP_ID): cv.use_id(MitsubishiUART),
     }
 ).extend(
     {
@@ -39,7 +39,7 @@ CONFIG_SCHEMA = cv.Schema(
 
 @coroutine
 async def to_code(config):
-    muart_component = await cg.get_variable(config[CONF_MITSUBISHI_IPT_ID])
+    muart_component = await cg.get_variable(config[CONF_MITSUBISHI_ITP_ID])
 
     # Buttons
     for button_designator, _ in BUTTONS.items():

--- a/esphome/components/mitsubishi_itp/button/muart_button.h
+++ b/esphome/components/mitsubishi_itp/button/muart_button.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "esphome/components/button/button.h"
-#include "mitsubishi_uart.h"
+#include "../mitsubishi_uart.h"
 
 namespace esphome {
 namespace mitsubishi_itp {

--- a/esphome/components/mitsubishi_itp/climate.py
+++ b/esphome/components/mitsubishi_itp/climate.py
@@ -3,10 +3,9 @@ import esphome.config_validation as cv
 from esphome.components import (
     climate,
     uart,
-    time,
-    sensor,
-    button,
     select,
+    sensor,
+    time,
 )
 from esphome.const import (
     CONF_CUSTOM_FAN_MODES,
@@ -42,9 +41,6 @@ CONF_TEMPERATURE_SOURCE_SELECT = "temperature_source_select"  # This is to creat
 CONF_VANE_POSITION_SELECT = "vane_position_select"
 CONF_HORIZONTAL_VANE_POSITION_SELECT = "horizontal_vane_position_select"
 
-CONF_BUTTONS = "buttons"
-CONF_FILTER_RESET_BUTTON = "filter_reset_button"
-
 CONF_TEMPERATURE_SOURCES = (
     "temperature_sources"  # This is for specifying additional sources
 )
@@ -68,10 +64,6 @@ TemperatureSourceSelect = mitsubishi_itp_ns.class_(
 VanePositionSelect = mitsubishi_itp_ns.class_("VanePositionSelect", select.Select)
 HorizontalVanePositionSelect = mitsubishi_itp_ns.class_(
     "HorizontalVanePositionSelect", select.Select
-)
-
-FilterResetButton = mitsubishi_itp_ns.class_(
-    "FilterResetButton", button.Button, cg.Component
 )
 
 DEFAULT_CLIMATE_MODES = ["OFF", "HEAT", "DRY", "COOL", "FAN_ONLY", "HEAT_COOL"]
@@ -152,31 +144,10 @@ SELECTS_SCHEMA = cv.All(
     }
 )
 
-BUTTONS = {
-    CONF_FILTER_RESET_BUTTON: (
-        "Filter Reset",
-        button.button_schema(
-            FilterResetButton,
-            entity_category=ENTITY_CATEGORY_CONFIG,
-            icon="mdi:restore",
-        ),
-    )
-}
-
-BUTTONS_SCHEMA = cv.All(
-    {
-        cv.Optional(
-            button_designator, default={"name": f"{button_name}"}
-        ): button_schema
-        for button_designator, (button_name, button_schema) in BUTTONS.items()
-    }
-)
-
 
 CONFIG_SCHEMA = BASE_SCHEMA.extend(
     {
         cv.Optional(CONF_SELECTS, default={}): SELECTS_SCHEMA,
-        cv.Optional(CONF_BUTTONS, default={}): BUTTONS_SCHEMA,
     }
 )
 
@@ -280,13 +251,6 @@ async def to_code(config):
         await select.register_select(
             select_component, select_conf, options=select_options
         )
-
-    # Buttons
-    for button_designator, (_, _) in BUTTONS.items():
-        button_conf = config[CONF_BUTTONS][button_designator]
-        button_component = await button.new_button(button_conf)
-        await cg.register_component(button_component, button_conf)
-        await cg.register_parented(button_component, muart_component)
 
     # Debug Settings
     if dam_conf := config.get(CONF_DISABLE_ACTIVE_MODE):

--- a/esphome/components/mitsubishi_itp/climate.py
+++ b/esphome/components/mitsubishi_itp/climate.py
@@ -13,11 +13,11 @@ from esphome.components import (
 from esphome.const import (
     CONF_CUSTOM_FAN_MODES,
     CONF_ID,
-    CONF_NAME,
     CONF_OUTDOOR_TEMPERATURE,
     CONF_SENSORS,
     CONF_SUPPORTED_FAN_MODES,
     CONF_SUPPORTED_MODES,
+    CONF_TIME_ID,
     DEVICE_CLASS_TEMPERATURE,
     DEVICE_CLASS_FREQUENCY,
     DEVICE_CLASS_HUMIDITY,
@@ -43,12 +43,10 @@ AUTO_LOAD = [
 ]
 DEPENDENCIES = [
     "uart",
-    "climate",
 ]
 
 CONF_UART_HEATPUMP = "uart_heatpump"
 CONF_UART_THERMOSTAT = "uart_thermostat"
-CONF_TIME_SOURCE = "time_source"
 
 CONF_THERMOSTAT_TEMPERATURE = "thermostat_temperature"
 CONF_THERMOSTAT_HUMIDITY = "thermostat_humidity"
@@ -109,17 +107,7 @@ BASE_SCHEMA = climate.CLIMATE_SCHEMA.extend(
         cv.GenerateID(CONF_ID): cv.declare_id(MitsubishiUART),
         cv.Required(CONF_UART_HEATPUMP): cv.use_id(uart.UARTComponent),
         cv.Optional(CONF_UART_THERMOSTAT): cv.use_id(uart.UARTComponent),
-        cv.Optional(CONF_TIME_SOURCE): cv.use_id(time.RealTimeClock),
-        # Overwrite name from ENTITY_BASE_SCHEMA with "Climate" as default
-        cv.Optional(CONF_NAME, default="Climate"): cv.Any(
-            cv.All(
-                cv.none,
-                cv.requires_friendly_name(
-                    "Name cannot be None when esphome->friendly_name is not set!"
-                ),
-            ),
-            cv.string,
-        ),
+        cv.Optional(CONF_TIME_ID): cv.use_id(time.RealTimeClock),
         cv.Optional(
             CONF_SUPPORTED_MODES, default=DEFAULT_CLIMATE_MODES
         ): cv.ensure_list(climate.validate_climate_mode),
@@ -361,12 +349,12 @@ async def to_code(config):
         SELECTS[CONF_TEMPERATURE_SOURCE_SELECT][2].append("Thermostat")
 
     # If RTC defined
-    if CONF_TIME_SOURCE in config:
-        rtc_component = await cg.get_variable(config[CONF_TIME_SOURCE])
+    if CONF_TIME_ID in config:
+        rtc_component = await cg.get_variable(config[CONF_TIME_ID])
         cg.add(getattr(muart_component, "set_time_source")(rtc_component))
     elif CONF_UART_THERMOSTAT in config and config.get(CONF_ENHANCED_MHK_SUPPORT):
         raise cv.RequiredFieldInvalid(
-            f"{CONF_TIME_SOURCE} is required if {CONF_ENHANCED_MHK_SUPPORT} is set."
+            f"{CONF_TIME_ID} is required if {CONF_ENHANCED_MHK_SUPPORT} is set."
         )
 
     # Traits

--- a/esphome/components/mitsubishi_itp/climate.py
+++ b/esphome/components/mitsubishi_itp/climate.py
@@ -143,18 +143,20 @@ async def to_code(config):
     if CONF_CUSTOM_FAN_MODES in config:
         cg.add(traits.set_supported_custom_fan_modes(config[CONF_CUSTOM_FAN_MODES]))
 
-    # # Add additional configured temperature sensors to the select menu
-    # for ts_id in config[CONF_TEMPERATURE_SOURCES]:
-    #     ts = await cg.get_variable(ts_id)
-    #     TEMPERATURE_SOURCE_OPTIONS.append(ts.get_name())
-    #     cg.add(
-    #         getattr(ts, "add_on_state_callback")(
-    #             # TODO: Is there anyway to do this without a raw expression?
-    #             cg.RawExpression(
-    #                 f"[](float v){{{getattr(muart_component, 'temperature_source_report')}({ts.get_name()}, v);}}"
-    #             )
-    #         )
-    #     )
+    # Add additional configured temperature sensors to the select menu
+    for ts_id in config[CONF_TEMPERATURE_SOURCES]:
+        ts = await cg.get_variable(ts_id)
+        cg.add(
+            getattr(muart_component, "register_temperature_source")(ts.get_name().str())
+        )
+        cg.add(
+            getattr(ts, "add_on_state_callback")(
+                # TODO: Is there anyway to do this without a raw expression?
+                cg.RawExpression(
+                    f"[](float v){{{getattr(muart_component, 'temperature_source_report')}({ts.get_name()}, v);}}"
+                )
+            )
+        )
 
     # Debug Settings
     if dam_conf := config.get(CONF_DISABLE_ACTIVE_MODE):

--- a/esphome/components/mitsubishi_itp/climate.py
+++ b/esphome/components/mitsubishi_itp/climate.py
@@ -48,7 +48,7 @@ mitsubishi_itp_ns = cg.esphome_ns.namespace("mitsubishi_itp")
 MitsubishiUART = mitsubishi_itp_ns.class_(
     "MitsubishiUART", cg.PollingComponent, climate.Climate
 )
-CONF_MITSUBISHI_IPT_ID = "mitsuibishi_itp_id"
+CONF_MITSUBISHI_ITP_ID = "mitsubishi_itp_id"
 
 DEFAULT_CLIMATE_MODES = ["OFF", "HEAT", "DRY", "COOL", "FAN_ONLY", "HEAT_COOL"]
 DEFAULT_FAN_MODES = ["AUTO", "QUIET", "LOW", "MEDIUM", "HIGH"]

--- a/esphome/components/mitsubishi_itp/mitsubishi_uart-packetprocessing.cpp
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart-packetprocessing.cpp
@@ -158,65 +158,71 @@ void MitsubishiUART::process_packet(const SettingsGetResponsePacket &packet) {
 
   publish_on_update_ |= fan_changed;
 
-  // TODO: It would probably be nice to have the enum->string mapping defined somewhere to avoid typos/errors
-  const std::string old_vane_position = vane_position_select_->state;
-  switch (packet.get_vane()) {
-    case SettingsSetRequestPacket::VANE_AUTO:
-      vane_position_select_->state = "Auto";
-      break;
-    case SettingsSetRequestPacket::VANE_1:
-      vane_position_select_->state = "1";
-      break;
-    case SettingsSetRequestPacket::VANE_2:
-      vane_position_select_->state = "2";
-      break;
-    case SettingsSetRequestPacket::VANE_3:
-      vane_position_select_->state = "3";
-      break;
-    case SettingsSetRequestPacket::VANE_4:
-      vane_position_select_->state = "4";
-      break;
-    case SettingsSetRequestPacket::VANE_5:
-      vane_position_select_->state = "5";
-      break;
-    case SettingsSetRequestPacket::VANE_SWING:
-      vane_position_select_->state = "Swing";
-      break;
-    default:
-      ESP_LOGW(TAG, "Vane in unknown position %x", packet.get_vane());
+  // If we don't have a vane position select, there is no where to report this data, and no need to parse it
+  if (vane_position_select_) {
+    // TODO: It would probably be nice to have the enum->string mapping defined somewhere to avoid typos/errors
+    const std::string old_vane_position = vane_position_select_->state;
+    switch (packet.get_vane()) {
+      case SettingsSetRequestPacket::VANE_AUTO:
+        vane_position_select_->state = "Auto";
+        break;
+      case SettingsSetRequestPacket::VANE_1:
+        vane_position_select_->state = "1";
+        break;
+      case SettingsSetRequestPacket::VANE_2:
+        vane_position_select_->state = "2";
+        break;
+      case SettingsSetRequestPacket::VANE_3:
+        vane_position_select_->state = "3";
+        break;
+      case SettingsSetRequestPacket::VANE_4:
+        vane_position_select_->state = "4";
+        break;
+      case SettingsSetRequestPacket::VANE_5:
+        vane_position_select_->state = "5";
+        break;
+      case SettingsSetRequestPacket::VANE_SWING:
+        vane_position_select_->state = "Swing";
+        break;
+      default:
+        ESP_LOGW(TAG, "Vane in unknown position %x", packet.get_vane());
+    }
+    publish_on_update_ |= (old_vane_position != vane_position_select_->state);
   }
-  publish_on_update_ |= (old_vane_position != vane_position_select_->state);
 
-  const std::string old_horizontal_vane_position = horizontal_vane_position_select_->state;
-  switch (packet.get_horizontal_vane()) {
-    case SettingsSetRequestPacket::HV_AUTO:
-      horizontal_vane_position_select_->state = "Auto";
-      break;
-    case SettingsSetRequestPacket::HV_LEFT_FULL:
-      horizontal_vane_position_select_->state = "<<";
-      break;
-    case SettingsSetRequestPacket::HV_LEFT:
-      horizontal_vane_position_select_->state = "<";
-      break;
-    case SettingsSetRequestPacket::HV_CENTER:
-      horizontal_vane_position_select_->state = "|";
-      break;
-    case SettingsSetRequestPacket::HV_RIGHT:
-      horizontal_vane_position_select_->state = ">";
-      break;
-    case SettingsSetRequestPacket::HV_RIGHT_FULL:
-      horizontal_vane_position_select_->state = ">>";
-      break;
-    case SettingsSetRequestPacket::HV_SPLIT:
-      horizontal_vane_position_select_->state = "<>";
-      break;
-    case SettingsSetRequestPacket::HV_SWING:
-      horizontal_vane_position_select_->state = "Swing";
-      break;
-    default:
-      ESP_LOGW(TAG, "Vane in unknown horizontal position %x", packet.get_horizontal_vane());
+  // If we don't have a horizontal vane position select, there is no where to report this data, and no need to parse it
+  if (horizontal_vane_position_select_) {
+    const std::string old_horizontal_vane_position = horizontal_vane_position_select_->state;
+    switch (packet.get_horizontal_vane()) {
+      case SettingsSetRequestPacket::HV_AUTO:
+        horizontal_vane_position_select_->state = "Auto";
+        break;
+      case SettingsSetRequestPacket::HV_LEFT_FULL:
+        horizontal_vane_position_select_->state = "<<";
+        break;
+      case SettingsSetRequestPacket::HV_LEFT:
+        horizontal_vane_position_select_->state = "<";
+        break;
+      case SettingsSetRequestPacket::HV_CENTER:
+        horizontal_vane_position_select_->state = "|";
+        break;
+      case SettingsSetRequestPacket::HV_RIGHT:
+        horizontal_vane_position_select_->state = ">";
+        break;
+      case SettingsSetRequestPacket::HV_RIGHT_FULL:
+        horizontal_vane_position_select_->state = ">>";
+        break;
+      case SettingsSetRequestPacket::HV_SPLIT:
+        horizontal_vane_position_select_->state = "<>";
+        break;
+      case SettingsSetRequestPacket::HV_SWING:
+        horizontal_vane_position_select_->state = "Swing";
+        break;
+      default:
+        ESP_LOGW(TAG, "Vane in unknown horizontal position %x", packet.get_horizontal_vane());
+    }
+    publish_on_update_ |= (old_horizontal_vane_position != horizontal_vane_position_select_->state);
   }
-  publish_on_update_ |= (old_horizontal_vane_position != horizontal_vane_position_select_->state);
 }
 
 void MitsubishiUART::process_packet(const CurrentTempGetResponsePacket &packet) {

--- a/esphome/components/mitsubishi_itp/mitsubishi_uart.cpp
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart.cpp
@@ -230,11 +230,21 @@ void MitsubishiUART::do_publish_() {
   }
 
   // Binary sensors automatically dedup publishes (I think) and so will only actually publish on change
-  filter_status_sensor_->publish_state(filter_status_sensor_->state);
-  defrost_sensor_->publish_state(defrost_sensor_->state);
-  preheat_sensor_->publish_state(preheat_sensor_->state);
-  standby_sensor_->publish_state(standby_sensor_->state);
-  isee_status_sensor_->publish_state(isee_status_sensor_->state);
+  if (filter_status_sensor_) {
+    filter_status_sensor_->publish_state(filter_status_sensor_->state);
+  }
+  if (defrost_sensor_) {
+    defrost_sensor_->publish_state(defrost_sensor_->state);
+  }
+  if (preheat_sensor_) {
+    preheat_sensor_->publish_state(preheat_sensor_->state);
+  }
+  if (standby_sensor_) {
+    standby_sensor_->publish_state(standby_sensor_->state);
+  }
+  if (isee_status_sensor_) {
+    isee_status_sensor_->publish_state(isee_status_sensor_->state);
+  }
 }
 
 bool MitsubishiUART::select_temperature_source(const std::string &state) {

--- a/esphome/components/mitsubishi_itp/mitsubishi_uart.h
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart.h
@@ -25,9 +25,9 @@ const float MUART_TEMPERATURE_STEP = 0.5;
 const std::string FAN_MODE_VERYHIGH = "Very High";
 
 const std::string TEMPERATURE_SOURCE_INTERNAL = "Internal";
-const uint32_t TEMPERATURE_SOURCE_TIMEOUT_MS = 420000;  // (7min) The heatpump will revert on its own in ~10min
-
 const std::string TEMPERATURE_SOURCE_THERMOSTAT = "Thermostat";
+
+const uint32_t TEMPERATURE_SOURCE_TIMEOUT_MS = 420000;  // (7min) The heatpump will revert on its own in ~10min
 
 // These are named to match with set fan speeds where possible.  "Very Low" is a special speed
 // for e.g. preheating or thermal off
@@ -198,9 +198,9 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   text_sensor::TextSensor *thermostat_battery_sensor_ = nullptr;
 
   // Selects
-  select::Select *temperature_source_select_;
-  select::Select *vane_position_select_;
-  select::Select *horizontal_vane_position_select_;
+  select::Select *temperature_source_select_ = nullptr;
+  select::Select *vane_position_select_ = nullptr;
+  select::Select *horizontal_vane_position_select_ = nullptr;
 
   // Temperature select extras
   std::map<std::string, size_t> temp_select_map_;  // Used to map strings to indexes for preference storage

--- a/esphome/components/mitsubishi_itp/mitsubishi_uart.h
+++ b/esphome/components/mitsubishi_itp/mitsubishi_uart.h
@@ -95,6 +95,8 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   bool select_vane_position(const std::string &state);
   bool select_horizontal_vane_position(const std::string &state);
 
+  // Adds an option to temperature_source_select_
+  void register_temperature_source(std::string temperature_source_name);
   // Used by external sources to report a temperature
   void temperature_source_report(const std::string &temperature_source, const float &v);
 
@@ -203,7 +205,8 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   select::Select *horizontal_vane_position_select_ = nullptr;
 
   // Temperature select extras
-  std::map<std::string, size_t> temp_select_map_;  // Used to map strings to indexes for preference storage
+  std::vector<std::string> temp_select_options_ = {
+      TEMPERATURE_SOURCE_INTERNAL};  // Used to map strings to indexes for preference storage
   std::string current_temperature_source_ = TEMPERATURE_SOURCE_INTERNAL;
   uint32_t last_received_temperature_ = millis();
 

--- a/esphome/components/mitsubishi_itp/select/__init__.py
+++ b/esphome/components/mitsubishi_itp/select/__init__.py
@@ -1,0 +1,97 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import (
+    select,
+)
+from esphome.components.mitsubishi_itp.climate import (
+    CONF_MITSUBISHI_IPT_ID,
+    mitsubishi_itp_ns,
+    MitsubishiUART,
+)
+from esphome.const import (
+    CONF_ID,
+    ENTITY_CATEGORY_CONFIG,
+    ENTITY_CATEGORY_NONE,
+)
+from esphome.core import coroutine
+
+CONF_TEMPERATURE_SOURCE = (
+    "temperature_source"  # This is to create a Select object for selecting a source
+)
+CONF_VANE_POSITION = "vane_position"
+CONF_HORIZONTAL_VANE_POSITION = "horizontal_vane_position"
+
+VANE_POSITIONS = ["Auto", "1", "2", "3", "4", "5", "Swing"]
+HORIZONTAL_VANE_POSITIONS = ["Auto", "<<", "<", "|", ">", ">>", "<>", "Swing"]
+
+TemperatureSourceSelect = mitsubishi_itp_ns.class_(
+    "TemperatureSourceSelect", select.Select
+)
+VanePositionSelect = mitsubishi_itp_ns.class_("VanePositionSelect", select.Select)
+HorizontalVanePositionSelect = mitsubishi_itp_ns.class_(
+    "HorizontalVanePositionSelect", select.Select
+)
+
+SELECTS = {
+    CONF_TEMPERATURE_SOURCE: (
+        select.select_schema(
+            TemperatureSourceSelect,
+            entity_category=ENTITY_CATEGORY_CONFIG,
+            icon="mdi:thermometer-check",
+        ),
+        [mitsubishi_itp_ns.TEMPERATURE_SOURCE_INTERNAL],
+    ),
+    CONF_VANE_POSITION: (
+        select.select_schema(
+            VanePositionSelect,
+            entity_category=ENTITY_CATEGORY_NONE,
+            icon="mdi:arrow-expand-vertical",
+        ),
+        VANE_POSITIONS,
+    ),
+    CONF_HORIZONTAL_VANE_POSITION: (
+        select.select_schema(
+            HorizontalVanePositionSelect,
+            entity_category=ENTITY_CATEGORY_NONE,
+            icon="mdi:arrow-expand-horizontal",
+        ),
+        HORIZONTAL_VANE_POSITIONS,
+    ),
+}
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_MITSUBISHI_IPT_ID): cv.use_id(MitsubishiUART),
+    }
+).extend(
+    {
+        cv.Optional(select_designator): select_schema
+        for select_designator, (
+            select_schema,
+            _,
+        ) in SELECTS.items()
+    }
+)
+
+
+@coroutine
+async def to_code(config):
+    muart_component = await cg.get_variable(config[CONF_MITSUBISHI_IPT_ID])
+
+    # Register selects
+    for select_designator, (
+        _,
+        select_options,
+    ) in SELECTS.items():
+        if select_conf := config.get(select_designator):
+            select_component = cg.new_Pvariable(select_conf[CONF_ID])
+            cg.add(
+                getattr(muart_component, f"set_{select_designator}_select")(
+                    select_component
+                )
+            )
+            await cg.register_parented(select_component, muart_component)
+
+            await select.register_select(
+                select_component, select_conf, options=select_options
+            )

--- a/esphome/components/mitsubishi_itp/select/__init__.py
+++ b/esphome/components/mitsubishi_itp/select/__init__.py
@@ -3,17 +3,17 @@ import esphome.config_validation as cv
 from esphome.components import (
     select,
 )
-from esphome.components.mitsubishi_itp.climate import (
-    CONF_MITSUBISHI_IPT_ID,
-    mitsubishi_itp_ns,
-    MitsubishiUART,
-)
 from esphome.const import (
     CONF_ID,
     ENTITY_CATEGORY_CONFIG,
     ENTITY_CATEGORY_NONE,
 )
 from esphome.core import coroutine
+from ...mitsubishi_itp.climate import (
+    CONF_MITSUBISHI_ITP_ID,
+    mitsubishi_itp_ns,
+    MitsubishiUART,
+)
 
 CONF_TEMPERATURE_SOURCE = (
     "temperature_source"  # This is to create a Select object for selecting a source
@@ -61,7 +61,7 @@ SELECTS = {
 
 CONFIG_SCHEMA = cv.Schema(
     {
-        cv.GenerateID(CONF_MITSUBISHI_IPT_ID): cv.use_id(MitsubishiUART),
+        cv.GenerateID(CONF_MITSUBISHI_ITP_ID): cv.use_id(MitsubishiUART),
     }
 ).extend(
     {
@@ -76,7 +76,7 @@ CONFIG_SCHEMA = cv.Schema(
 
 @coroutine
 async def to_code(config):
-    muart_component = await cg.get_variable(config[CONF_MITSUBISHI_IPT_ID])
+    muart_component = await cg.get_variable(config[CONF_MITSUBISHI_ITP_ID])
 
     # Register selects
     for select_designator, (

--- a/esphome/components/mitsubishi_itp/select/muart_select.h
+++ b/esphome/components/mitsubishi_itp/select/muart_select.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "esphome/components/select/select.h"
-#include "mitsubishi_uart.h"
+#include "../mitsubishi_uart.h"
 
 namespace esphome {
 namespace mitsubishi_itp {

--- a/esphome/components/mitsubishi_itp/sensor.py
+++ b/esphome/components/mitsubishi_itp/sensor.py
@@ -5,10 +5,6 @@ from esphome.components import (
     binary_sensor,
     text_sensor,
 )
-from esphome.components.mitsubishi_itp.climate import (
-    CONF_MITSUBISHI_ITP_ID,
-    MitsubishiUART,
-)
 from esphome.const import (
     CONF_ID,
     CONF_OUTDOOR_TEMPERATURE,
@@ -21,6 +17,10 @@ from esphome.const import (
     UNIT_PERCENT,
 )
 from esphome.core import coroutine
+from .climate import (
+    CONF_MITSUBISHI_ITP_ID,
+    MitsubishiUART,
+)
 
 CONF_THERMOSTAT_BATTERY = "thermostat_battery"
 CONF_THERMOSTAT_HUMIDITY = "thermostat_humidity"

--- a/esphome/components/mitsubishi_itp/sensor.py
+++ b/esphome/components/mitsubishi_itp/sensor.py
@@ -5,6 +5,10 @@ from esphome.components import (
     binary_sensor,
     text_sensor,
 )
+from esphome.components.mitsubishi_itp.climate import (
+    CONF_MITSUBISHI_ITP_ID,
+    MitsubishiUART,
+)
 from esphome.const import (
     CONF_ID,
     CONF_OUTDOOR_TEMPERATURE,
@@ -15,10 +19,6 @@ from esphome.const import (
     UNIT_CELSIUS,
     UNIT_HERTZ,
     UNIT_PERCENT,
-)
-from esphome.components.mitsubishi_itp.climate import (
-    CONF_MITSUBISHI_IPT_ID,
-    MitsubishiUART,
 )
 from esphome.core import coroutine
 
@@ -112,7 +112,7 @@ SENSORS = dict[str, tuple[cv.Schema, callable]](
 
 CONFIG_SCHEMA = cv.Schema(
     {
-        cv.GenerateID(CONF_MITSUBISHI_IPT_ID): cv.use_id(MitsubishiUART),
+        cv.GenerateID(CONF_MITSUBISHI_ITP_ID): cv.use_id(MitsubishiUART),
     }
 ).extend(
     {
@@ -127,7 +127,7 @@ CONFIG_SCHEMA = cv.Schema(
 
 @coroutine
 async def to_code(config):
-    muart_component = await cg.get_variable(config[CONF_MITSUBISHI_IPT_ID])
+    muart_component = await cg.get_variable(config[CONF_MITSUBISHI_ITP_ID])
 
     # Sensors
 

--- a/esphome/components/mitsubishi_itp/sensor.py
+++ b/esphome/components/mitsubishi_itp/sensor.py
@@ -1,0 +1,147 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import (
+    sensor,
+    binary_sensor,
+    text_sensor,
+)
+from esphome.const import (
+    CONF_ID,
+    CONF_OUTDOOR_TEMPERATURE,
+    DEVICE_CLASS_TEMPERATURE,
+    DEVICE_CLASS_FREQUENCY,
+    DEVICE_CLASS_HUMIDITY,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_CELSIUS,
+    UNIT_HERTZ,
+    UNIT_PERCENT,
+)
+from esphome.components.mitsubishi_itp.climate import (
+    CONF_MITSUBISHI_IPT_ID,
+    MitsubishiUART,
+)
+from esphome.core import coroutine
+
+CONF_THERMOSTAT_BATTERY = "thermostat_battery"
+CONF_THERMOSTAT_HUMIDITY = "thermostat_humidity"
+CONF_THERMOSTAT_TEMPERATURE = "thermostat_temperature"
+
+
+CONF_ERROR_CODE = "error_code"
+CONF_ISEE_STATUS = "isee_status"
+
+# TODO Storing the registration function here seems weird, but I can't figure out how to determine schema type later
+SENSORS = dict[str, tuple[cv.Schema, callable]](
+    {
+        "actual_fan": (
+            text_sensor.text_sensor_schema(
+                icon="mdi:fan",
+            ),
+            text_sensor.register_text_sensor,
+        ),
+        "compressor_frequency": (
+            sensor.sensor_schema(
+                unit_of_measurement=UNIT_HERTZ,
+                device_class=DEVICE_CLASS_FREQUENCY,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            sensor.register_sensor,
+        ),
+        "defrost": (
+            binary_sensor.binary_sensor_schema(icon="mdi:snowflake-melt"),
+            binary_sensor.register_binary_sensor,
+        ),
+        CONF_ERROR_CODE: (
+            text_sensor.text_sensor_schema(icon="mdi:alert-circle-outline"),
+            text_sensor.register_text_sensor,
+        ),
+        "filter_status": (
+            binary_sensor.binary_sensor_schema(
+                device_class="problem", icon="mdi:air-filter"
+            ),
+            binary_sensor.register_binary_sensor,
+        ),
+        CONF_ISEE_STATUS: (
+            binary_sensor.binary_sensor_schema(icon="mdi:eye"),
+            binary_sensor.register_binary_sensor,
+        ),
+        CONF_OUTDOOR_TEMPERATURE: (
+            sensor.sensor_schema(
+                unit_of_measurement=UNIT_CELSIUS,
+                device_class=DEVICE_CLASS_TEMPERATURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+                accuracy_decimals=1,
+                icon="mdi:sun-thermometer-outline",
+            ),
+            sensor.register_sensor,
+        ),
+        "preheat": (
+            binary_sensor.binary_sensor_schema(icon="mdi:heating-coil"),
+            binary_sensor.register_binary_sensor,
+        ),
+        "standby": (
+            binary_sensor.binary_sensor_schema(icon="mdi:pause-circle-outline"),
+            binary_sensor.register_binary_sensor,
+        ),
+        CONF_THERMOSTAT_BATTERY: (
+            text_sensor.text_sensor_schema(
+                icon="mdi:battery",
+            ),
+            text_sensor.register_text_sensor,
+        ),
+        CONF_THERMOSTAT_HUMIDITY: (
+            sensor.sensor_schema(
+                unit_of_measurement=UNIT_PERCENT,
+                device_class=DEVICE_CLASS_HUMIDITY,
+                state_class=STATE_CLASS_MEASUREMENT,
+                accuracy_decimals=0,
+            ),
+            sensor.register_sensor,
+        ),
+        CONF_THERMOSTAT_TEMPERATURE: (
+            sensor.sensor_schema(
+                unit_of_measurement=UNIT_CELSIUS,
+                device_class=DEVICE_CLASS_TEMPERATURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+                accuracy_decimals=1,
+            ),
+            sensor.register_sensor,
+        ),
+    }
+)
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_MITSUBISHI_IPT_ID): cv.use_id(MitsubishiUART),
+    }
+).extend(
+    {
+        cv.Optional(sensor_designator): sensor_schema
+        for sensor_designator, (
+            sensor_schema,
+            _,
+        ) in SENSORS.items()
+    }
+)
+
+
+@coroutine
+async def to_code(config):
+    muart_component = await cg.get_variable(config[CONF_MITSUBISHI_IPT_ID])
+
+    # Sensors
+
+    for sensor_designator, (
+        _,
+        registration_function,
+    ) in SENSORS.items():
+        if sensor_conf := config.get(sensor_designator):
+            sensor_component = cg.new_Pvariable(sensor_conf[CONF_ID])
+
+            await registration_function(sensor_component, sensor_conf)
+
+            cg.add(
+                getattr(muart_component, f"set_{sensor_designator}_sensor")(
+                    sensor_component
+                )
+            )

--- a/tests/components/mitsubishi_itp/common.yaml
+++ b/tests/components/mitsubishi_itp/common.yaml
@@ -34,6 +34,7 @@ uart:
 
 climate:
   - platform: mitsubishi_itp
+    name: Climate
     uart_heatpump: hp_uart
     uart_thermostat: tstat_uart
     time_id: homeassistant_time

--- a/tests/components/mitsubishi_itp/common.yaml
+++ b/tests/components/mitsubishi_itp/common.yaml
@@ -36,7 +36,7 @@ climate:
   - platform: mitsubishi_itp
     uart_heatpump: hp_uart
     uart_thermostat: tstat_uart
-    time_source: homeassistant_time
+    time_id: homeassistant_time
     update_interval: 12s
     temperature_sources:
       - fake_temp


### PR DESCRIPTION
These changes address some of the feedback from the PR.  Notably:

- Remove default name
- Use time_id
- Don't depend or auto_load climate
- Sensors, buttons, and selects are broken out into their own directories/files.

These changes do *not* address:
- Avoiding AUTO_LOAD by making the sensors listeners (will begin work on this now)
- Moving from a climate-hub to a climate component and separate hub (unclear yet if this is reasonable / feasible)