### PR TITLE
Fix routing `SettingsSetRequest` from MHK

### DIFF
--- a/esphome/components/mitsubishi_itp/mitsubishi_itp-packetprocessing.cpp
+++ b/esphome/components/mitsubishi_itp/mitsubishi_itp-packetprocessing.cpp
@@ -249,6 +249,7 @@ void MitsubishiUART::process_packet(const SettingsSetRequestPacket &packet) {
   ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
 
   // forward this packet as-is; we're just intercepting to log.
+  route_packet_(packet) ;
   alert_listeners_(packet);
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Looks like a call to `route_packet_` got dropped at some point, this adds it back.

Thanks @sle118 for the fix, I just made the PR :)

Tested on my SVZ-KP24NA with MHK2 thermostat

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/muart-group/esphome/issues/61
