### PR TITLE
Remove active_mode

### DIFF
--- a/esphome/components/mitsubishi_itp/climate.py
+++ b/esphome/components/mitsubishi_itp/climate.py
@@ -19,7 +19,6 @@ DEPENDENCIES = [
 CONF_UART_HEATPUMP = "uart_heatpump"
 CONF_UART_THERMOSTAT = "uart_thermostat"
 
-CONF_DISABLE_ACTIVE_MODE = "disable_active_mode"
 CONF_ENHANCED_MHK_SUPPORT = (
     "enhanced_mhk"  # EXPERIMENTAL. Will be set to default eventually.
 )
@@ -48,7 +47,6 @@ CONFIG_SCHEMA = climate.CLIMATE_SCHEMA.extend(
         cv.Optional(CONF_CUSTOM_FAN_MODES, default=["VERYHIGH"]): cv.ensure_list(
             validate_custom_fan_modes
         ),
-        cv.Optional(CONF_DISABLE_ACTIVE_MODE, default=False): cv.boolean,
         cv.Optional(CONF_ENHANCED_MHK_SUPPORT, default=False): cv.boolean,
         cv.Optional(CONF_RECALL_SETPOINT, default=False): cv.boolean,
     }
@@ -119,9 +117,6 @@ async def to_code(config):
         cg.add(traits.set_supported_custom_fan_modes(config[CONF_CUSTOM_FAN_MODES]))
 
     # Debug Settings
-    if dam_conf := config.get(CONF_DISABLE_ACTIVE_MODE):
-        cg.add(getattr(mitp_component, "set_active_mode")(not dam_conf))
-
     if enhanced_mhk_protocol := config.get(CONF_ENHANCED_MHK_SUPPORT):
         cg.add(
             getattr(mitp_component, "set_enhanced_mhk_support")(enhanced_mhk_protocol)

--- a/esphome/components/mitsubishi_itp/mitsubishi_itp-climatecall.cpp
+++ b/esphome/components/mitsubishi_itp/mitsubishi_itp-climatecall.cpp
@@ -5,9 +5,6 @@ namespace mitsubishi_itp {
 
 // Called to instruct a change of the climate controls
 void MitsubishiUART::control(const climate::ClimateCall &call) {
-  if (!active_mode_)
-    return;  // If we're not in active mode, ignore control requests
-
   SettingsSetRequestPacket set_request_packet = SettingsSetRequestPacket();
 
   // Apply fan settings

--- a/esphome/components/mitsubishi_itp/mitsubishi_itp-packetprocessing.cpp
+++ b/esphome/components/mitsubishi_itp/mitsubishi_itp-packetprocessing.cpp
@@ -257,9 +257,8 @@ void MitsubishiUART::process_packet(const RemoteTemperatureSetRequestPacket &pac
   ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
 
   // Only send this temperature packet to the heatpump if Thermostat is the selected source,
-  // or we're in passive mode (since in passive mode we're not generating any packets to
-  // set the temperature) otherwise just respond to the thermostat to keep it happy.
-  if (current_temperature_source_ == TEMPERATURE_SOURCE_THERMOSTAT || !active_mode_) {
+  // otherwise just respond to the thermostat to keep it happy.
+  if (current_temperature_source_ == TEMPERATURE_SOURCE_THERMOSTAT) {
     route_packet_(packet);
   } else {
     ts_bridge_->send_packet(SetResponsePacket());

--- a/esphome/components/mitsubishi_itp/mitsubishi_itp.h
+++ b/esphome/components/mitsubishi_itp/mitsubishi_itp.h
@@ -78,9 +78,6 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   // Button triggers
   void reset_filter_status();
 
-  // Turns on or off actively sending packets
-  void set_active_mode(const bool active) { active_mode_ = active; };
-
   // Turns on or off Kumo emulation mode
   void set_enhanced_mhk_support(const bool supports) { enhanced_mhk_support_ = supports; }
 
@@ -175,9 +172,6 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   std::string current_temperature_source_;
   uint32_t last_received_temperature_ = millis();
   bool temperature_source_timeout_ = false;  // Has the current source timed out?
-
-  void send_if_active_(const Packet &packet);
-  bool active_mode_ = true;
 
   // used to track whether to support/handle the enhanced MHK protocol packets
   bool enhanced_mhk_support_ = false;


### PR DESCRIPTION
# What does this implement/fix?

Active/passive mode was intended primarily for debugging, but is making some of the code less readable and more complex.  This switch is being removed and if needed can be implemented in a separate component (or probably purely in ESPHome config)
